### PR TITLE
feat: add simplified swap and transfer

### DIFF
--- a/solidity/interfaces/ISwapProxy.sol
+++ b/solidity/interfaces/ISwapProxy.sol
@@ -7,6 +7,26 @@ pragma solidity >=0.8.7 <0.9.0;
  *         are allowed and which aren't
  */
 interface ISwapProxy {
+  /// @notice The parameters for swap & transfer
+  struct SwapAndTransferParams {
+    // The swapper that will execute the call
+    address swapper;
+    // The account that needs to be approved for token transfers
+    address allowanceTarget;
+    // The actual swap execution
+    bytes swapData;
+    // The token that will be swapped
+    address tokenIn;
+    // The max amount of token in that will be spent
+    uint256 maxAmountIn;
+    // The token that will be received
+    address tokenOut;
+    // The account that should receive the swapped tokens
+    address recipient;
+    // Determine if we need to check if there are any unspent tokens in to return to the caller
+    bool checkUnspentTokensIn;
+  }
+
   /// @notice The parameters for swap & transfer (many)
   struct SwapAndTransferManyParams {
     // The swapper that will execute the call
@@ -59,6 +79,16 @@ interface ISwapProxy {
    * @return Whether it is allowlisted for swaps
    */
   function isAllowlisted(address account) external view returns (bool);
+
+  /**
+   * @notice Executes a swap and sends the swapped funds to the given recipient
+   *         This function is basically a wrapper that acts as a proxy between the caller and the swapper.
+   *         It is meant to add swap & transfer capabilities to swappers that do not support it natively
+   * @dev This function can only be called by swappers that are allowlisted
+   *      This function does not delegate the call to the swapper
+   * @param params The parameters for the swap and transfer
+   */
+  function swapAndTransfer(SwapAndTransferParams calldata params) external payable;
 
   /**
    * @notice Executes a swap and sends the swapped funds to the given recipient

--- a/test/integration/comprehensive-swap-test.spec.ts
+++ b/test/integration/comprehensive-swap-test.spec.ts
@@ -210,12 +210,13 @@ describe('Comprehensive Swap Test', () => {
         await swapProxy.connect(admin).allowSwappers([quote.swapperAddress]);
         await WETH.connect(wethWhale).transfer(caller.address, maxAmountIn);
         await WETH.connect(caller).approve(swapProxy.address, maxAmountIn);
-        await swapProxy.connect(caller).swapAndTransferMany({
+        await swapProxy.connect(caller).swapAndTransfer({
           swapper: quote.swapperAddress,
           allowanceTarget: quote.allowanceTarget,
           swapData: quote.data,
-          tokensIn: [{ token: WETH.address, amount: maxAmountIn }],
-          tokensOut: [USDC.address],
+          tokenIn: WETH.address,
+          maxAmountIn,
+          tokenOut: USDC.address,
           recipient: recipient.address,
           checkUnspentTokensIn: !!checkUnspentTokensIn,
         });

--- a/test/unit/swap-proxy.spec.ts
+++ b/test/unit/swap-proxy.spec.ts
@@ -83,6 +83,22 @@ describe('SwapProxy', () => {
   const AMOUNT_OUT = 1234567;
 
   swapAndTransferTest({
+    func: 'swapAndTransfer',
+    defaultParams: async () => {
+      const { data } = await swapper1.populateTransaction.executeSwap(tokenIn.address, tokenOut.address, AMOUNT_IN);
+      return {
+        swapper: swapper1.address,
+        allowanceTarget: swapper1.address,
+        swapData: data!,
+        tokenIn: tokenIn.address,
+        maxAmountIn: AMOUNT_IN,
+        tokenOut: tokenOut.address,
+        recipient: RECIPIENT,
+      };
+    },
+  });
+
+  swapAndTransferTest({
     func: 'swapAndTransferMany',
     defaultParams: async () => {
       const { data } = await swapper1.populateTransaction.executeSwap(tokenIn.address, tokenOut.address, AMOUNT_IN);
@@ -97,7 +113,7 @@ describe('SwapProxy', () => {
     },
   });
 
-  function swapAndTransferTest({ func, defaultParams }: { func: 'swapAndTransferMany'; defaultParams: () => Promise<any> }) {
+  function swapAndTransferTest({ func, defaultParams }: { func: 'swapAndTransferMany' | 'swapAndTransfer'; defaultParams: () => Promise<any> }) {
     describe(func, () => {
       given(async () => {
         tokenIn.allowance.returns(AMOUNT_IN);


### PR DESCRIPTION
We are now adding a simplified version of `swapAndTransfer` that takes a single token in and a single token out. We are doing because most DEXes only take single token in/out, and the simplified version is close to 2.5k cheaper in terms of gas

```
···································|···························································································|·············|·············|··············|···············|··············
|  SwapProxy                       ·  swapAndTransfer((address,address,bytes,address,uint256,address,address,bool))            ·      43882  ·      72431  ·       52438  ·           29  ·          -  │
···································|···························································································|·············|·············|··············|···············|··············
|  SwapProxy                       ·  swapAndTransferMany((address,address,bytes,(address,uint256)[],address[],address,bool))  ·      46344  ·      74581  ·       55149  ·           29  ·          -  │
···································|···························································································|·············|·············|··············|···············|··············
```