### PR TITLE
feat: add swapper registry

### DIFF
--- a/solidity/contracts/SwapperRegistry.sol
+++ b/solidity/contracts/SwapperRegistry.sol
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.8.7 <0.9.0;
+
+import '@openzeppelin/contracts/access/AccessControl.sol';
+import '../interfaces/ISwapperRegistry.sol';
+
+contract SwapperRegistry is AccessControl, ISwapperRegistry {
+  bytes32 public constant SUPER_ADMIN_ROLE = keccak256('SUPER_ADMIN_ROLE');
+  bytes32 public constant ADMIN_ROLE = keccak256('ADMIN_ROLE');
+
+  /// @inheritdoc ISwapperRegistry
+  mapping(address => bool) public isAllowlisted;
+
+  constructor(
+    address[] memory _initialAllowlisted,
+    address _superAdmin,
+    address[] memory _initialAdmins
+  ) {
+    if (_superAdmin == address(0)) revert ZeroAddress();
+    _setupRole(SUPER_ADMIN_ROLE, _superAdmin);
+    _setRoleAdmin(ADMIN_ROLE, SUPER_ADMIN_ROLE);
+    for (uint256 i; i < _initialAdmins.length; i++) {
+      _setupRole(ADMIN_ROLE, _initialAdmins[i]);
+    }
+
+    if (_initialAllowlisted.length > 0) {
+      for (uint256 i; i < _initialAllowlisted.length; i++) {
+        isAllowlisted[_initialAllowlisted[i]] = true;
+      }
+      emit AllowedSwappers(_initialAllowlisted);
+    }
+  }
+
+  /// @inheritdoc ISwapperRegistry
+  function allowSwappers(address[] calldata _swappers) external onlyRole(ADMIN_ROLE) {
+    for (uint256 i; i < _swappers.length; i++) {
+      isAllowlisted[_swappers[i]] = true;
+    }
+    emit AllowedSwappers(_swappers);
+  }
+
+  /// @inheritdoc ISwapperRegistry
+  function removeSwappersFromAllowlist(address[] calldata _swappers) external onlyRole(ADMIN_ROLE) {
+    for (uint256 i; i < _swappers.length; i++) {
+      isAllowlisted[_swappers[i]] = false;
+    }
+    emit RemoveSwappersFromAllowlist(_swappers);
+  }
+}

--- a/solidity/interfaces/ISwapperRegistry.sol
+++ b/solidity/interfaces/ISwapperRegistry.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.8.7 <0.9.0;
+
+/**
+ * @notice This contract will act as a registry to allowlist swappers. Different contracts from the Mean
+ *         ecosystem will ask this contract if an address is a valid swapper or not
+ */
+interface ISwapperRegistry {
+  /// @notice Thrown when one of the parameters is a zero address
+  error ZeroAddress();
+
+  /**
+   * @notice Emitted when swappers are removed from the allowlist
+   * @param swappers The swappers that were removed
+   */
+  event RemoveSwappersFromAllowlist(address[] swappers);
+
+  /**
+   * @notice Emitted when new swappers are added to the allowlist
+   * @param swappers The swappers that were added
+   */
+  event AllowedSwappers(address[] swappers);
+
+  /**
+   * @notice Returns whether a given account is allowlisted for swaps
+   * @param account The address to check
+   * @return Whether it is allowlisted for swaps
+   */
+  function isAllowlisted(address account) external view returns (bool);
+
+  /**
+   * @notice Adds a list of swappers to the allowlist
+   * @dev Can only be called by users with the admin role
+   * @param swappers The list of swappers to add
+   */
+  function allowSwappers(address[] calldata swappers) external;
+
+  /**
+   * @notice Removes given swappers from the allowlist
+   * @dev Can only be called by users with the admin role
+   * @param swappers The list of swappers to remove
+   */
+  function removeSwappersFromAllowlist(address[] calldata swappers) external;
+}

--- a/test/unit/swapper-registry.spec.ts
+++ b/test/unit/swapper-registry.spec.ts
@@ -1,0 +1,106 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { constants } from 'ethers';
+import { behaviours } from '@utils';
+import { given, then, when } from '@utils/bdd';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { TransactionResponse } from '@ethersproject/abstract-provider';
+import { SwapperRegistry, SwapperRegistry__factory } from '@typechained';
+import { snapshot } from '@utils/evm';
+
+describe('SwapperRegistry', () => {
+  const ALLOWED_SWAPPER = '0x0000000000000000000000000000000000000001';
+  const NOT_ALLOWED_SWAPPER = '0x0000000000000000000000000000000000000002';
+
+  let superAdmin: SignerWithAddress, admin: SignerWithAddress, caller: SignerWithAddress;
+  let swapperRegistryFactory: SwapperRegistry__factory;
+  let swapperRegistry: SwapperRegistry;
+  let superAdminRole: string, adminRole: string;
+  let snapshotId: string;
+
+  before('Setup accounts and contracts', async () => {
+    [caller, superAdmin, admin] = await ethers.getSigners();
+    swapperRegistryFactory = await ethers.getContractFactory('solidity/contracts/SwapperRegistry.sol:SwapperRegistry');
+    swapperRegistry = await swapperRegistryFactory.deploy([ALLOWED_SWAPPER], superAdmin.address, [admin.address]);
+    superAdminRole = await swapperRegistry.SUPER_ADMIN_ROLE();
+    adminRole = await swapperRegistry.ADMIN_ROLE();
+    snapshotId = await snapshot.take();
+  });
+
+  beforeEach(async () => {
+    await snapshot.revert(snapshotId);
+  });
+
+  describe('constructor', () => {
+    when('super admin is zero address', () => {
+      then('tx is reverted with reason error', async () => {
+        await behaviours.deployShouldRevertWithMessage({
+          contract: swapperRegistryFactory,
+          args: [[], constants.AddressZero, []],
+          message: 'ZeroAddress',
+        });
+      });
+    });
+    when('all arguments are valid', () => {
+      then('super admin is set correctly', async () => {
+        const hasRole = await swapperRegistry.hasRole(superAdminRole, superAdmin.address);
+        expect(hasRole).to.be.true;
+      });
+      then('initial admins are set correctly', async () => {
+        const hasRole = await swapperRegistry.hasRole(adminRole, admin.address);
+        expect(hasRole).to.be.true;
+      });
+      then('super admin role is set as admin role', async () => {
+        const admin = await swapperRegistry.getRoleAdmin(adminRole);
+        expect(admin).to.equal(superAdminRole);
+      });
+      then('initial allowlisted are set correctly', async () => {
+        expect(await swapperRegistry.isAllowlisted(ALLOWED_SWAPPER)).to.be.true;
+      });
+    });
+  });
+
+  describe('allowSwappers', () => {
+    when('swapper is allowed', () => {
+      let tx: TransactionResponse;
+      given(async () => {
+        tx = await swapperRegistry.connect(admin).allowSwappers([NOT_ALLOWED_SWAPPER]);
+      });
+      then(`it is reflected correctly`, async () => {
+        expect(await swapperRegistry.isAllowlisted(NOT_ALLOWED_SWAPPER)).to.be.true;
+      });
+      then('event is emitted', async () => {
+        await expect(tx).to.emit(swapperRegistry, 'AllowedSwappers').withArgs([NOT_ALLOWED_SWAPPER]);
+      });
+    });
+    behaviours.shouldBeExecutableOnlyByRole({
+      contract: () => swapperRegistry,
+      funcAndSignature: 'allowSwappers',
+      params: () => [[NOT_ALLOWED_SWAPPER]],
+      addressWithRole: () => admin,
+      role: () => adminRole,
+    });
+  });
+
+  describe('removeSwappersFromAllowlist', () => {
+    when('swapper is removed', () => {
+      let tx: TransactionResponse;
+      given(async () => {
+        tx = await swapperRegistry.connect(admin).removeSwappersFromAllowlist([ALLOWED_SWAPPER]);
+      });
+      then(`it is reflected correctly`, async () => {
+        expect(await swapperRegistry.isAllowlisted(ALLOWED_SWAPPER)).to.be.false;
+      });
+      then('event is emitted', async () => {
+        await expect(tx).to.emit(swapperRegistry, 'RemoveSwappersFromAllowlist').withArgs([ALLOWED_SWAPPER]);
+      });
+    });
+    behaviours.shouldBeExecutableOnlyByRole({
+      contract: () => swapperRegistry,
+      funcAndSignature: 'removeSwappersFromAllowlist',
+      params: () => [[ALLOWED_SWAPPER]],
+      addressWithRole: () => admin,
+      role: () => adminRole,
+    });
+  });
+});


### PR DESCRIPTION
_Note: we just copied this code (and tests) from the SwapProxy_ 

We are now adding the `SwapperRegistry`. This contract will act as a registry to allowlist swappers. Different contracts from the Mean ecosystem will ask this contract if an address is a valid swapper or not