### PR TITLE
feat: add swap adapter

### DIFF
--- a/solidity/contracts/SwapAdapter.sol
+++ b/solidity/contracts/SwapAdapter.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.8.7 <0.9.0;
+
+import '../interfaces/ISwapAdapter.sol';
+
+abstract contract SwapAdapter is ISwapAdapter {
+  ISwapperRegistry public immutable SWAPPER_REGISTRY;
+
+  constructor(address _swapperRegistry) {
+    if (_swapperRegistry == address(0)) revert ZeroAddress();
+    SWAPPER_REGISTRY = ISwapperRegistry(_swapperRegistry);
+  }
+}

--- a/solidity/contracts/test/SwapAdapter.sol
+++ b/solidity/contracts/test/SwapAdapter.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.8.7 <0.9.0;
+
+import '../SwapAdapter.sol';
+
+contract SwapAdapterMock is SwapAdapter {
+  constructor(address _swapperRegistry) SwapAdapter(_swapperRegistry) {}
+}

--- a/solidity/interfaces/ISwapAdapter.sol
+++ b/solidity/interfaces/ISwapAdapter.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.8.7 <0.9.0;
+
+import './ISwapperRegistry.sol';
+
+/**
+ * @notice This abstract contract will give contracts that implement it swapping capabilities. It will
+ *         take a swapper and a swap's data, and if the swapper is valid, it will execute the swap
+ */
+interface ISwapAdapter {
+  /// @notice Thrown when one of the parameters is a zero address
+  error ZeroAddress();
+
+  /**
+   * @notice Returns the address of the swapper registry
+   * @dev Cannot be modified
+   * @return The address of the swapper registry
+   */
+  function SWAPPER_REGISTRY() external view returns (ISwapperRegistry);
+}

--- a/test/unit/swap-adapter.spec.ts
+++ b/test/unit/swap-adapter.spec.ts
@@ -1,0 +1,43 @@
+import { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { constants } from 'ethers';
+import { behaviours } from '@utils';
+import { then, when } from '@utils/bdd';
+import { ISwapperRegistry, SwapAdapterMock, SwapAdapterMock__factory } from '@typechained';
+import { snapshot } from '@utils/evm';
+import { FakeContract, smock } from '@defi-wonderland/smock';
+
+describe('SwapAdapter', () => {
+  let swapAdapterFactory: SwapAdapterMock__factory;
+  let swapAdapter: SwapAdapterMock;
+  let registry: FakeContract<ISwapperRegistry>;
+  let snapshotId: string;
+
+  before('Setup accounts and contracts', async () => {
+    registry = await smock.fake('ISwapperRegistry');
+    swapAdapterFactory = await ethers.getContractFactory('solidity/contracts/test/SwapAdapter.sol:SwapAdapterMock');
+    swapAdapter = await swapAdapterFactory.deploy(registry.address);
+    snapshotId = await snapshot.take();
+  });
+
+  beforeEach(async () => {
+    await snapshot.revert(snapshotId);
+  });
+
+  describe('constructor', () => {
+    when('registry is zero address', () => {
+      then('tx is reverted with reason error', async () => {
+        await behaviours.deployShouldRevertWithMessage({
+          contract: swapAdapterFactory,
+          args: [constants.AddressZero],
+          message: 'ZeroAddress',
+        });
+      });
+    });
+    when('all arguments are valid', () => {
+      then('registry is set correctly', async () => {
+        expect(await swapAdapter.SWAPPER_REGISTRY()).to.equal(registry.address);
+      });
+    });
+  });
+});


### PR DESCRIPTION
We are now implementing the `SwapAdapter`. This abstract contract will give contracts that implement it swapping capabilities. It will take a swapper and a swap's data, and if the swapper is valid, it will execute the swap