### PR TITLE
feat: add take from sender

### DIFF
--- a/solidity/contracts/SwapAdapter.sol
+++ b/solidity/contracts/SwapAdapter.sol
@@ -1,13 +1,20 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.7 <0.9.0;
 
+import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 import '../interfaces/ISwapAdapter.sol';
 
 abstract contract SwapAdapter is ISwapAdapter {
+  using SafeERC20 for IERC20;
+
   ISwapperRegistry public immutable SWAPPER_REGISTRY;
 
   constructor(address _swapperRegistry) {
     if (_swapperRegistry == address(0)) revert ZeroAddress();
     SWAPPER_REGISTRY = ISwapperRegistry(_swapperRegistry);
+  }
+
+  function _takeFromMsgSender(IERC20 _token, uint256 _amount) internal virtual {
+    _token.safeTransferFrom(msg.sender, address(this), _amount);
   }
 }

--- a/solidity/contracts/test/SwapAdapter.sol
+++ b/solidity/contracts/test/SwapAdapter.sol
@@ -5,4 +5,8 @@ import '../SwapAdapter.sol';
 
 contract SwapAdapterMock is SwapAdapter {
   constructor(address _swapperRegistry) SwapAdapter(_swapperRegistry) {}
+
+  function internalTakeFromMsgSender(IERC20 _token, uint256 _amount) external {
+    _takeFromMsgSender(_token, _amount);
+  }
 }

--- a/solidity/interfaces/ISwapAdapter.sol
+++ b/solidity/interfaces/ISwapAdapter.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.7 <0.9.0;
 
+import '@openzeppelin/contracts/interfaces/IERC20.sol';
 import './ISwapperRegistry.sol';
 
 /**

--- a/test/unit/swap-adapter.spec.ts
+++ b/test/unit/swap-adapter.spec.ts
@@ -1,27 +1,38 @@
-import { expect } from 'chai';
+import chai, { expect } from 'chai';
 import { ethers } from 'hardhat';
 import { constants } from 'ethers';
 import { behaviours } from '@utils';
-import { then, when } from '@utils/bdd';
-import { ISwapperRegistry, SwapAdapterMock, SwapAdapterMock__factory } from '@typechained';
+import { given, then, when } from '@utils/bdd';
+import { IERC20, ISwapperRegistry, SwapAdapterMock, SwapAdapterMock__factory } from '@typechained';
 import { snapshot } from '@utils/evm';
 import { FakeContract, smock } from '@defi-wonderland/smock';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+
+chai.use(smock.matchers);
 
 describe('SwapAdapter', () => {
+  const AMOUNT = 1000000;
+
+  let caller: SignerWithAddress;
   let swapAdapterFactory: SwapAdapterMock__factory;
   let swapAdapter: SwapAdapterMock;
   let registry: FakeContract<ISwapperRegistry>;
   let snapshotId: string;
+  let token: FakeContract<IERC20>;
 
   before('Setup accounts and contracts', async () => {
+    [caller] = await ethers.getSigners();
     registry = await smock.fake('ISwapperRegistry');
     swapAdapterFactory = await ethers.getContractFactory('solidity/contracts/test/SwapAdapter.sol:SwapAdapterMock');
     swapAdapter = await swapAdapterFactory.deploy(registry.address);
+    token = await smock.fake('IERC20');
     snapshotId = await snapshot.take();
   });
 
   beforeEach(async () => {
     await snapshot.revert(snapshotId);
+    token.transferFrom.reset();
+    token.transferFrom.returns(true);
   });
 
   describe('constructor', () => {
@@ -37,6 +48,17 @@ describe('SwapAdapter', () => {
     when('all arguments are valid', () => {
       then('registry is set correctly', async () => {
         expect(await swapAdapter.SWAPPER_REGISTRY()).to.equal(registry.address);
+      });
+    });
+  });
+
+  describe('_takeFromMsgSender', () => {
+    when('function is called', () => {
+      given(async () => {
+        await swapAdapter.internalTakeFromMsgSender(token.address, AMOUNT);
+      });
+      then('token is called correctly', async () => {
+        expect(token.transferFrom).to.have.been.calledOnceWith(caller.address, swapAdapter.address, AMOUNT);
       });
     });
   });


### PR DESCRIPTION
We are now going to slowly implement `swapAndTransfer`. Since this contract is meant to be inherited, we are going to split the implementation into small `internal` functions, so that other contracts can build variations on their own