### PR TITLE
feat: add take swap and trancer

### DIFF
--- a/solidity/contracts/SwapAdapter.sol
+++ b/solidity/contracts/SwapAdapter.sol
@@ -26,6 +26,17 @@ abstract contract SwapAdapter is ISwapAdapter {
     }
   }
 
+  /// @inheritdoc ISwapAdapter
+  function takeSwapAndTransfer(TakeSwapAndTransferParams calldata _parameters) external payable onlyAllowlisted(_parameters.swapper) {
+    _takeFromMsgSender(_parameters.tokenIn, _parameters.maxAmountIn);
+    _maxApproveSpenderIfNeeded(_parameters.tokenIn, _parameters.allowanceTarget, _parameters.maxAmountIn);
+    _executeSwap(_parameters.swapper, _parameters.swapData);
+    if (_parameters.checkUnspentTokensIn) {
+      _sendBalanceToMsgSender(_parameters.tokenIn);
+    }
+    _sendBalanceToRecipient(_parameters.tokenOut, _parameters.recipient);
+  }
+
   /**
    * @notice Takes the given amount of tokens from the caller
    * @param _token The token to check

--- a/solidity/contracts/test/SwapAdapter.sol
+++ b/solidity/contracts/test/SwapAdapter.sol
@@ -24,10 +24,16 @@ contract SwapAdapterMock is SwapAdapter {
     IERC20 token;
   }
 
+  struct SendBalanceToRecipientCall {
+    IERC20 token;
+    address recipient;
+  }
+
   TakeFromMsgSenderCall public takeFromMsgSenderCall;
   MaxApproveSpenderCall public maxApproveSpenderCall;
   ExecuteSwapCall public executeSwapCall;
   SendBalanceToMsgSenderCall public sendBalanceToMsgSenderCall;
+  SendBalanceToRecipientCall public sendBalanceToRecipientCall;
 
   constructor(address _swapperRegistry) SwapAdapter(_swapperRegistry) {}
 
@@ -77,6 +83,11 @@ contract SwapAdapterMock is SwapAdapter {
 
   function internalSendBalanceToRecipient(IERC20 _token, address _recipient) external {
     _sendBalanceToRecipient(_token, _recipient);
+  }
+
+  function _sendBalanceToRecipient(IERC20 _token, address _recipient) internal override {
+    sendBalanceToRecipientCall = SendBalanceToRecipientCall(_token, _recipient);
+    super._sendBalanceToRecipient(_token, _recipient);
   }
 
   function internalAssertSwapperIsAllowlisted(address _swapper) external view {

--- a/solidity/interfaces/ISwapAdapter.sol
+++ b/solidity/interfaces/ISwapAdapter.sol
@@ -25,6 +25,26 @@ interface ISwapAdapter {
     bool checkUnspentTokensIn;
   }
 
+  // @notice The parameters to execute take, swap & transfer
+  struct TakeSwapAndTransferParams {
+    // The swapper that will execute the call
+    address swapper;
+    // The account that needs to be approved for token transfers
+    address allowanceTarget;
+    // The actual swap execution
+    bytes swapData;
+    // The token that will be swapped
+    IERC20 tokenIn;
+    // The max amount of "token in" that can be spent
+    uint256 maxAmountIn;
+    // Determine if we need to check if there are any unspent "tokens in" to return to the caller
+    bool checkUnspentTokensIn;
+    // The token that will be received in exchange for "token in"
+    IERC20 tokenOut;
+    // The account that should receive the swapped tokens
+    address recipient;
+  }
+
   /// @notice Thrown when one of the parameters is a zero address
   error ZeroAddress();
 
@@ -49,4 +69,14 @@ interface ISwapAdapter {
    * @param params The parameters for the swap
    */
   function takeAndSwap(TakeAndSwapParams calldata params) external payable;
+
+  /**
+   * @notice Takes tokens from the caller, executes a swap against a given swapper and transfer the
+   *         swapped tokens to the given recipient. This function will take the funds from the user
+   *         and approve the swapper before executing the swap. It is meant to add swap capabilities
+   *         to contracts that do not support it natively
+   * @dev This function can only be executed with swappers that are allowlisted
+   * @param params The parameters for the swap
+   */
+  function takeSwapAndTransfer(TakeSwapAndTransferParams calldata params) external payable;
 }


### PR DESCRIPTION
We are now implementing `takeSwapAndTransfer`. This function takes tokens from the caller, executes a swap against a given swapper and transfer the swapped tokens to the given recipient.