### PR TITLE
fix: dont take from caller with protocol token

### DIFF
--- a/solidity/contracts/extensions/Shared.sol
+++ b/solidity/contracts/extensions/Shared.sol
@@ -3,6 +3,8 @@ pragma solidity >=0.8.7 <0.9.0;
 
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 
+address constant PROTOCOL_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
 /// @notice An amount to take form the caller
 struct TakeFromCaller {
   // The token that will be taken from the caller

--- a/solidity/contracts/extensions/TakeAndRunSwap.sol
+++ b/solidity/contracts/extensions/TakeAndRunSwap.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.7 <0.9.0;
 
+import './Shared.sol';
 import '../SwapAdapter.sol';
 
 abstract contract TakeAndRunSwap is SwapAdapter {
@@ -27,13 +28,15 @@ abstract contract TakeAndRunSwap is SwapAdapter {
    * @param _parameters The parameters for the swap
    */
   function takeAndRunSwap(TakeAndRunSwapParams calldata _parameters) external payable onlyAllowlisted(_parameters.swapper) {
-    _takeFromMsgSender(_parameters.tokenIn, _parameters.maxAmountIn);
-    _maxApproveSpenderIfNeeded(
-      _parameters.tokenIn,
-      _parameters.allowanceTarget,
-      _parameters.swapper == _parameters.allowanceTarget, // If target is a swapper, then it's ok as allowance target
-      _parameters.maxAmountIn
-    );
+    if (address(_parameters.tokenIn) != PROTOCOL_TOKEN) {
+      _takeFromMsgSender(_parameters.tokenIn, _parameters.maxAmountIn);
+      _maxApproveSpenderIfNeeded(
+        _parameters.tokenIn,
+        _parameters.allowanceTarget,
+        _parameters.swapper == _parameters.allowanceTarget, // If target is a swapper, then it's ok as allowance target
+        _parameters.maxAmountIn
+      );
+    }
     _executeSwap(_parameters.swapper, _parameters.swapData, msg.value);
     if (_parameters.checkUnspentTokensIn) {
       _sendBalanceToRecipient(_parameters.tokenIn, msg.sender);

--- a/solidity/contracts/extensions/TakeRunSwapAndTransfer.sol
+++ b/solidity/contracts/extensions/TakeRunSwapAndTransfer.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.7 <0.9.0;
 
+import './Shared.sol';
 import '../SwapAdapter.sol';
 
 abstract contract TakeRunSwapAndTransfer is SwapAdapter {
@@ -31,13 +32,15 @@ abstract contract TakeRunSwapAndTransfer is SwapAdapter {
    * @param _parameters The parameters for the swap
    */
   function takeRunSwapAndTransfer(TakeRunSwapAndTransferParams calldata _parameters) external payable onlyAllowlisted(_parameters.swapper) {
-    _takeFromMsgSender(_parameters.tokenIn, _parameters.maxAmountIn);
-    _maxApproveSpenderIfNeeded(
-      _parameters.tokenIn,
-      _parameters.allowanceTarget,
-      _parameters.swapper == _parameters.allowanceTarget, // If target is a swapper, then it's ok as allowance target
-      _parameters.maxAmountIn
-    );
+    if (address(_parameters.tokenIn) != PROTOCOL_TOKEN) {
+      _takeFromMsgSender(_parameters.tokenIn, _parameters.maxAmountIn);
+      _maxApproveSpenderIfNeeded(
+        _parameters.tokenIn,
+        _parameters.allowanceTarget,
+        _parameters.swapper == _parameters.allowanceTarget, // If target is a swapper, then it's ok as allowance target
+        _parameters.maxAmountIn
+      );
+    }
     _executeSwap(_parameters.swapper, _parameters.swapData, msg.value);
     if (_parameters.checkUnspentTokensIn) {
       _sendBalanceToRecipient(_parameters.tokenIn, msg.sender);

--- a/solidity/contracts/extensions/TakeRunSwapsAndTransferMany.sol
+++ b/solidity/contracts/extensions/TakeRunSwapsAndTransferMany.sol
@@ -32,8 +32,10 @@ abstract contract TakeRunSwapsAndTransferMany is SwapAdapter {
    * @param _parameters The parameters for the swap
    */
   function takeRunSwapsAndTransferMany(TakeRunSwapsAndTransferManyParams calldata _parameters) external payable {
-    // Take from caller
-    _takeFromMsgSender(_parameters.tokenIn, _parameters.maxAmountIn);
+    if (address(_parameters.tokenIn) != PROTOCOL_TOKEN) {
+      // Take from caller
+      _takeFromMsgSender(_parameters.tokenIn, _parameters.maxAmountIn);
+    }
 
     // Validate that all swappers are allowlisted
     for (uint256 i; i < _parameters.swappers.length; i++) {

--- a/test/unit/extensions/take-and-run-swap.spec.ts
+++ b/test/unit/extensions/take-and-run-swap.spec.ts
@@ -111,5 +111,30 @@ contract('TakeAndRunSwap', () => {
         calls: [{ token: token.address, recipient: caller.address }],
       }));
     });
+    when('token in is protocol token', () => {
+      given(async () => {
+        await extensions.takeAndRunSwap({
+          swapper: swapper.address,
+          allowanceTarget: ACCOUNT,
+          swapData: swapData,
+          tokenIn: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+          maxAmountIn: 0,
+          checkUnspentTokensIn: false,
+        });
+      });
+      thenTakeFromMsgSenderIsCalledCorrectly(() => ({
+        contract: extensions,
+        calls: [],
+      }));
+      thenMaxApproveSpenderIsCalledCorrectly(() => ({
+        contract: extensions,
+        calls: [],
+      }));
+      thenExecuteSwapIsCalledCorrectly(() => ({
+        contract: extensions,
+        calls: [{ swapper: swapper.address, swapData, value: 0 }],
+      }));
+      thenSendBalanceToRecipientIsNotCalled(() => extensions);
+    });
   });
 });

--- a/test/unit/extensions/take-run-swap-and-transfer.spec.ts
+++ b/test/unit/extensions/take-run-swap-and-transfer.spec.ts
@@ -122,5 +122,43 @@ contract('TakeRunSwapAndTransfer', () => {
         ],
       }));
     });
+
+    when('token is is protocol token', () => {
+      given(async () => {
+        await extensions.takeRunSwapAndTransfer(
+          {
+            swapper: swapper.address,
+            allowanceTarget: swapper.address,
+            swapData: swapData,
+            tokenIn: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+            maxAmountIn: AMOUNT,
+            checkUnspentTokensIn: false,
+            tokenOut: tokenOut.address,
+            recipient: ACCOUNT,
+          },
+          { value: 123456 }
+        );
+      });
+      thenAllowlistWasCheckedForSwappers(() => ({
+        registry,
+        swappers: [swapper.address],
+      }));
+      thenTakeFromMsgSenderIsCalledCorrectly(() => ({
+        contract: extensions,
+        calls: [],
+      }));
+      thenMaxApproveSpenderIsCalledCorrectly(() => ({
+        contract: extensions,
+        calls: [],
+      }));
+      thenExecuteSwapIsCalledCorrectly(() => ({
+        contract: extensions,
+        calls: [{ swapper: swapper.address, swapData, value: 123456 }],
+      }));
+      thenSendBalanceToRecipientIsCalledCorrectly(() => ({
+        contract: extensions,
+        calls: [{ token: tokenOut.address, recipient: ACCOUNT }],
+      }));
+    });
   });
 });

--- a/test/unit/extensions/take-run-swaps-and-transfer-many.spec.ts
+++ b/test/unit/extensions/take-run-swaps-and-transfer-many.spec.ts
@@ -108,5 +108,53 @@ contract('TakeRunSwapsAndTransferMany', () => {
         ],
       }));
     });
+    when('token is is protocol token', () => {
+      given(async () => {
+        await extensions.takeRunSwapsAndTransferMany(
+          {
+            tokenIn: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+            maxAmountIn: AMOUNT,
+            allowanceTargets: [],
+            swappers: [swapper1.address, swapper2.address],
+            swaps: [swapData, swapData],
+            swapContext: [
+              { value: 150000, swapperIndex: 0 },
+              { value: 50000, swapperIndex: 1 },
+            ],
+            transferOutBalance: [
+              { token: tokenOut1.address, recipient: ACCOUNT },
+              { token: tokenOut2.address, recipient: ACCOUNT },
+            ],
+          },
+          { value: 200000 }
+        );
+      });
+      thenTakeFromMsgSenderIsCalledCorrectly(() => ({
+        contract: extensions,
+        calls: [],
+      }));
+      thenMaxApproveSpenderIsCalledCorrectly(() => ({
+        contract: extensions,
+        calls: [],
+      }));
+      thenAllowlistWasCheckedForSwappers(() => ({
+        registry,
+        swappers: [swapper1.address, swapper2.address],
+      }));
+      thenExecuteSwapIsCalledCorrectly(() => ({
+        contract: extensions,
+        calls: [
+          { swapper: swapper1.address, swapData, value: 150000 },
+          { swapper: swapper2.address, swapData, value: 50000 },
+        ],
+      }));
+      thenSendBalanceToRecipientIsCalledCorrectly(() => ({
+        contract: extensions,
+        calls: [
+          { token: tokenOut1.address, recipient: ACCOUNT },
+          { token: tokenOut2.address, recipient: ACCOUNT },
+        ],
+      }));
+    });
   });
 });


### PR DESCRIPTION
We realized that we were assuming that the `tokenIn` was always an ERC20. When it isn't, then there is no need to take tokens from the caller, or approve anything. So we are not taking this into account

This came up when trying to add some integration tests. #ThankGodForTests