### PR TITLE
fix: support protocol token as token out

### DIFF
--- a/solidity/contracts/SwapAdapter.sol
+++ b/solidity/contracts/SwapAdapter.sol
@@ -5,6 +5,8 @@ import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 import '@openzeppelin/contracts/utils/Address.sol';
 import '../interfaces/ISwapAdapter.sol';
 
+address constant PROTOCOL_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+
 abstract contract SwapAdapter is ISwapAdapter {
   using SafeERC20 for IERC20;
   using Address for address;
@@ -81,9 +83,16 @@ abstract contract SwapAdapter is ISwapAdapter {
    * @param _recipient The recipient of the token balance
    */
   function _sendBalanceToRecipient(address _token, address _recipient) internal virtual {
-    uint256 _balance = IERC20(_token).balanceOf(address(this));
-    if (_balance > 0) {
-      IERC20(_token).safeTransfer(_recipient, _balance);
+    if (_token == PROTOCOL_TOKEN) {
+      uint256 _balance = address(this).balance;
+      if (_balance > 0) {
+        payable(_recipient).transfer(_balance);
+      }
+    } else {
+      uint256 _balance = IERC20(_token).balanceOf(address(this));
+      if (_balance > 0) {
+        IERC20(_token).safeTransfer(_recipient, _balance);
+      }
     }
   }
 

--- a/solidity/contracts/extensions/Shared.sol
+++ b/solidity/contracts/extensions/Shared.sol
@@ -3,8 +3,6 @@ pragma solidity >=0.8.7 <0.9.0;
 
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 
-address constant PROTOCOL_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
-
 /// @notice An amount to take form the caller
 struct TakeFromCaller {
   // The token that will be taken from the caller

--- a/solidity/contracts/extensions/TakeAndRunSwap.sol
+++ b/solidity/contracts/extensions/TakeAndRunSwap.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.7 <0.9.0;
 
-import './Shared.sol';
 import '../SwapAdapter.sol';
 
 abstract contract TakeAndRunSwap is SwapAdapter {

--- a/solidity/contracts/extensions/TakeRunSwapAndTransfer.sol
+++ b/solidity/contracts/extensions/TakeRunSwapAndTransfer.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.7 <0.9.0;
 
-import './Shared.sol';
 import '../SwapAdapter.sol';
 
 abstract contract TakeRunSwapAndTransfer is SwapAdapter {


### PR DESCRIPTION
In #37 we realized that we weren't supporting the protocol token (ETH/BNB/MATIC) correctly as `token in`. Well we weren't supporting it as `token out` either, but we had to separate the PRs so that they were smaller