### PR TITLE
test: add take and run swap integration

### DIFF
--- a/test/integration/assertions.ts
+++ b/test/integration/assertions.ts
@@ -1,0 +1,19 @@
+import { IERC20 } from '@mean-finance/deterministic-factory/typechained';
+import { expect } from 'chai';
+import { BigNumber } from 'ethers';
+import { ethers } from 'hardhat';
+
+export async function expectETHBalanceToBeEmpty(hasAddress: { address: string }) {
+  const balance = await ethers.provider.getBalance(hasAddress.address);
+  expect(balance).to.equal(0);
+}
+
+export async function expectBalanceToBeEmpty(token: IERC20, hasAddress: { address: string }) {
+  const balance = await token.balanceOf(hasAddress.address);
+  expect(balance).to.equal(0);
+}
+
+export async function expectBalanceToBeGreatherThan(token: IERC20, minAmountOut: BigNumber, hasAddress: { address: string }) {
+  const balance = await token.balanceOf(hasAddress.address);
+  expect(balance.gte(minAmountOut)).to.be.true;
+}

--- a/test/integration/dex-adapters.ts
+++ b/test/integration/dex-adapters.ts
@@ -1,0 +1,98 @@
+import { BigNumber, BigNumberish } from 'ethers';
+import { swap as paraswapQuote } from './dexes/paraswap';
+import { quote as zrxQuote } from './dexes/zrx';
+import { swap as oneInchQuote } from './dexes/oneinch';
+
+export type QuoteInput = {
+  tokenIn: string;
+  tokenOut: string;
+  amount: BigNumberish;
+  userAddress: string;
+  trade: 'buy' | 'sell';
+  chainId: number;
+  slippagePercentage: number;
+  recipient?: string;
+};
+
+export type Quote = {
+  swapperAddress: string;
+  allowanceTarget: string;
+  amountIn: BigNumberish;
+  amountOut: BigNumberish;
+  data: string;
+};
+
+export async function paraswapAdapter({
+  tokenIn,
+  tokenOut,
+  amount,
+  trade,
+  chainId,
+  slippagePercentage,
+  recipient,
+  userAddress,
+}: QuoteInput): Promise<Quote> {
+  const quote = await paraswapQuote({
+    srcToken: tokenIn,
+    destToken: tokenOut,
+    amount: amount,
+    userAddress,
+    side: trade.toUpperCase() as any,
+    network: chainId,
+    slippage: slippagePercentage,
+    receiver: recipient,
+  });
+  return {
+    swapperAddress: quote.to,
+    allowanceTarget: quote.allowanceTarget,
+    amountIn: quote.srcAmount,
+    amountOut: quote.destAmount,
+    data: quote.data,
+  };
+}
+
+export async function zrxAdapter({ tokenIn, tokenOut, amount, trade, chainId, slippagePercentage }: QuoteInput): Promise<Quote> {
+  const quote = await zrxQuote({
+    chainId,
+    sellToken: tokenIn,
+    buyToken: tokenOut,
+    buyAmount: trade === 'buy' ? amount : undefined,
+    sellAmount: trade === 'sell' ? amount : undefined,
+    slippagePercentage: slippagePercentage / 100,
+  });
+  return {
+    swapperAddress: quote.to,
+    allowanceTarget: quote.allowanceTarget,
+    amountIn: quote.sellAmount,
+    amountOut: quote.buyAmount,
+    data: quote.data,
+  };
+}
+
+export async function oneInchAdapter({
+  tokenIn,
+  tokenOut,
+  amount,
+  trade,
+  chainId,
+  userAddress,
+  slippagePercentage,
+}: QuoteInput): Promise<Quote> {
+  if (trade === 'buy') throw new Error('1inch does not support but');
+  const quote = await oneInchQuote(chainId, {
+    tokenIn,
+    tokenOut,
+    amountIn: BigNumber.from(amount),
+    fromAddress: userAddress,
+    slippage: slippagePercentage,
+    disableEstimate: true,
+    allowPartialFill: false,
+  });
+  return {
+    swapperAddress: quote.tx.to,
+    allowanceTarget: quote.tx.to,
+    amountIn: quote.fromTokenAmount,
+    amountOut: quote.toTokenAmount,
+    data: quote.tx.data,
+  };
+}

--- a/test/integration/dex-aggregators-integration.spec.ts
+++ b/test/integration/dex-aggregators-integration.spec.ts
@@ -1,64 +1,28 @@
-import hre, { deployments, ethers, getNamedAccounts } from 'hardhat';
-import { evm, wallet } from '@utils';
+import { ethers } from 'hardhat';
 import { given, then, when } from '@utils/bdd';
-import { expect } from 'chai';
-import { getNodeUrl } from 'utils/env';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { JsonRpcSigner } from '@ethersproject/providers';
 import { IERC20, SwapperRegistry, SwapProxy } from '@typechained';
-import { BigNumber, BigNumberish, constants, utils } from 'ethers';
-import { abi as IERC20_ABI } from '@openzeppelin/contracts/build/contracts/IERC20.json';
-import { DeterministicFactory, DeterministicFactory__factory } from '@mean-finance/deterministic-factory/typechained';
+import { BigNumber, utils } from 'ethers';
 import { snapshot } from '@utils/evm';
-import { setTestChainId } from 'utils/deploy';
-import { quote as zrxQuote } from './dexes/zrx';
-import { swap as oneInchQuote } from './dexes/oneinch';
-import { swap as paraswapQuote } from './dexes/paraswap';
+import { expectBalanceToBeEmpty, expectBalanceToBeGreatherThan } from './assertions';
+import { deployContractsAndReturnSigners, getQuoteAndAllowlistSwapper } from './utils';
+import { oneInchAdapter, paraswapAdapter, Quote, QuoteInput, zrxAdapter } from './dex-adapters';
 
-const CHAIN = { chain: 'ethereum', chainId: 1 };
-
-const WETH_ADDRESS = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
-const WETH_WHALE_ADDRESS = '0xf04a5cc80b1e94c69b48f5ee68a08cd2f09a7c3e';
-const USDC_ADDRESS = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
-const SLIPPAGE_PERCENTAGE = 0.3;
 const AMOUNT_EXACT_IN = utils.parseEther('1');
 const AMOUNT_EXACT_OUT = utils.parseUnits('1000', 6);
 
 describe('DEX Aggregators - Integration', () => {
-  let swapperRegistry: SwapperRegistry;
+  let registry: SwapperRegistry;
   let swapProxy: SwapProxy;
   let WETH: IERC20, USDC: IERC20;
-  let admin: JsonRpcSigner, wethWhale: JsonRpcSigner;
+  let wethWhale: JsonRpcSigner;
   let caller: SignerWithAddress, recipient: SignerWithAddress;
   let snapshotId: string;
 
-  type Quote = {
-    swapperAddress: string;
-    allowanceTarget: string;
-    amountIn: BigNumberish;
-    amountOut: BigNumberish;
-    data: string;
-  };
-
   before(async () => {
-    const { deployer: deployerAddress } = await hre.getNamedAccounts();
-    const deployer = await ethers.getSigner(deployerAddress);
-    await fork({ ...CHAIN, deployer });
-    await deployments.fixture(['SwapProxy'], { keepExistingDeployments: true });
-
-    swapperRegistry = await ethers.getContract<SwapperRegistry>('SwapperRegistry');
-    swapProxy = await ethers.getContract<SwapProxy>('SwapProxy');
-    WETH = await ethers.getContractAt(IERC20_ABI, WETH_ADDRESS);
-    USDC = await ethers.getContractAt(IERC20_ABI, USDC_ADDRESS);
-
-    const { admin: adminAddress } = await getNamedAccounts();
-    admin = await wallet.impersonate(adminAddress);
-    await ethers.provider.send('hardhat_setBalance', [adminAddress, '0xffffffffffffffff']);
-
+    ({ registry, swapProxy, WETH, USDC, wethWhale } = await deployContractsAndReturnSigners());
     [caller, recipient] = await ethers.getSigners();
-    wethWhale = await wallet.impersonate(WETH_WHALE_ADDRESS);
-    await ethers.provider.send('hardhat_setBalance', [WETH_WHALE_ADDRESS, '0xffffffffffffffff']);
-
     snapshotId = await snapshot.take();
   });
 
@@ -69,158 +33,67 @@ describe('DEX Aggregators - Integration', () => {
   swapAndTransferTest({
     swapper: '0x',
     type: 'Exact In',
-    getQuote: async ({ tokenIn, tokenOut, chainId, slippagePercentage }) => {
-      const quote = await zrxQuote({
-        chainId,
-        sellToken: tokenIn,
-        buyToken: tokenOut,
-        sellAmount: AMOUNT_EXACT_IN,
-        slippagePercentage: slippagePercentage / 100,
-      });
-      return {
-        swapperAddress: quote.to,
-        allowanceTarget: quote.allowanceTarget,
-        amountIn: quote.sellAmount,
-        amountOut: quote.buyAmount,
-        data: quote.data,
-      };
-    },
+    quoter: zrxAdapter,
   });
 
   swapAndTransferTest({
     swapper: '0x',
     type: 'Exact Out',
-    getQuote: async ({ tokenIn, tokenOut, chainId, slippagePercentage }) => {
-      const quote = await zrxQuote({
-        chainId,
-        sellToken: tokenIn,
-        buyToken: tokenOut,
-        buyAmount: AMOUNT_EXACT_OUT,
-        slippagePercentage: slippagePercentage / 100,
-      });
-      return {
-        swapperAddress: quote.to,
-        allowanceTarget: quote.allowanceTarget,
-        amountIn: quote.sellAmount,
-        amountOut: quote.buyAmount,
-        data: quote.data,
-      };
-    },
+    quoter: zrxAdapter,
   });
 
   swapAndTransferTest({
     swapper: '1inch',
     type: 'Exact In',
-    getQuote: async ({ tokenIn, tokenOut, chainId, slippagePercentage }) => {
-      const quote = await oneInchQuote(chainId, {
-        tokenIn,
-        tokenOut,
-        amountIn: AMOUNT_EXACT_IN,
-        fromAddress: swapProxy.address,
-        slippage: slippagePercentage,
-        disableEstimate: true,
-        allowPartialFill: false,
-      });
-      return {
-        swapperAddress: quote.tx.to,
-        allowanceTarget: quote.tx.to,
-        amountIn: quote.fromTokenAmount,
-        amountOut: quote.toTokenAmount,
-        data: quote.tx.data,
-      };
-    },
+    quoter: oneInchAdapter,
   });
 
   swapAndTransferTest({
     swapper: 'Paraswap',
     type: 'Exact In',
-    getQuote: async ({ tokenIn, tokenOut, chainId, slippagePercentage }) => {
-      const quote = await paraswapQuote({
-        srcToken: tokenIn,
-        destToken: tokenOut,
-        amount: AMOUNT_EXACT_IN,
-        userAddress: swapProxy.address,
-        side: 'SELL',
-        network: chainId,
-        slippage: slippagePercentage,
-      });
-      return {
-        swapperAddress: quote.to,
-        allowanceTarget: quote.allowanceTarget,
-        amountIn: quote.srcAmount,
-        amountOut: quote.destAmount,
-        data: quote.data,
-      };
-    },
+    quoter: paraswapAdapter,
   });
 
   swapAndTransferTest({
     swapper: 'Paraswap',
     type: 'Exact Out',
     checkUnspentTokensIn: true,
-    getQuote: async ({ tokenIn, tokenOut, chainId, slippagePercentage }) => {
-      const quote = await paraswapQuote({
-        srcToken: tokenIn,
-        destToken: tokenOut,
-        amount: AMOUNT_EXACT_OUT,
-        userAddress: swapProxy.address,
-        side: 'BUY',
-        network: chainId,
-        slippage: slippagePercentage,
-      });
-      return {
-        swapperAddress: quote.to,
-        allowanceTarget: quote.allowanceTarget,
-        amountIn: quote.srcAmount,
-        amountOut: quote.destAmount,
-        data: quote.data,
-      };
-    },
+    quoter: paraswapAdapter,
   });
 
   function swapAndTransferTest({
     swapper,
     type,
-    getQuote,
+    quoter,
     checkUnspentTokensIn,
   }: {
     swapper: string;
     type: 'Exact In' | 'Exact Out';
     checkUnspentTokensIn?: boolean;
-    getQuote: (_: { tokenIn: string; tokenOut: string; chainId: number; slippagePercentage: number }) => Promise<Quote>;
+    quoter: (input: QuoteInput) => Promise<Quote>;
   }) {
     describe(swapper + ' (' + type + ')', () => {
-      let amountOut: BigNumber, minAmountOut: BigNumber;
-      let amountIn: BigNumber, maxAmountIn: BigNumber;
+      let minAmountOut: BigNumber;
       given(async () => {
-        const quote = await getQuote({
-          tokenIn: WETH.address,
-          tokenOut: USDC.address,
-          chainId: CHAIN.chainId,
-          slippagePercentage: SLIPPAGE_PERCENTAGE,
+        const quote = await getQuoteAndAllowlistSwapper({
+          swapProxy,
+          registry,
+          tokenIn: WETH,
+          tokenOut: USDC,
+          trade: type === 'Exact In' ? 'sell' : 'buy',
+          amount: type === 'Exact In' ? AMOUNT_EXACT_IN : AMOUNT_EXACT_OUT,
+          recipient: recipient,
+          quoter,
         });
-        amountIn = BigNumber.from(quote.amountIn);
-        amountOut = BigNumber.from(quote.amountOut);
-        if (type === 'Exact In') {
-          maxAmountIn = amountIn;
-          minAmountOut = amountOut.sub(calculatePercentage(amountOut, SLIPPAGE_PERCENTAGE));
-        } else {
-          maxAmountIn = amountIn.add(calculatePercentage(amountIn, SLIPPAGE_PERCENTAGE));
-          minAmountOut = amountOut;
-        }
-
-        await swapperRegistry.connect(admin).allowSwappers([quote.swapperAddress]);
-        if (quote.allowanceTarget !== quote.swapperAddress) {
-          await swapperRegistry.connect(admin).allowSupplementaryAllowanceTargets([quote.allowanceTarget]);
-        }
-        await WETH.connect(wethWhale).transfer(caller.address, maxAmountIn);
-        await WETH.connect(caller).approve(swapProxy.address, maxAmountIn);
+        minAmountOut = quote.minAmountOut;
+        await WETH.connect(wethWhale).transfer(caller.address, quote.maxAmountIn);
+        await WETH.connect(caller).approve(swapProxy.address, quote.maxAmountIn);
         await swapProxy.connect(caller).takeRunSwapAndTransfer({
           swapper: quote.swapperAddress,
           allowanceTarget: quote.allowanceTarget,
           swapData: quote.data,
           tokenIn: WETH.address,
-          maxAmountIn,
+          maxAmountIn: quote.maxAmountIn,
           tokenOut: USDC.address,
           recipient: recipient.address,
           checkUnspentTokensIn: !!checkUnspentTokensIn,
@@ -229,60 +102,14 @@ describe('DEX Aggregators - Integration', () => {
 
       when('swap & transfer is executed through the swap proxy', () => {
         if (!checkUnspentTokensIn) {
-          then(`caller has no 'from' token left`, async () => {
-            const balance = await WETH.balanceOf(caller.address);
-            expect(balance).to.equal(0);
-          });
+          then(`caller has no 'from' token left`, () => expectBalanceToBeEmpty(WETH, caller));
         }
-        then(`caller has no 'to' token`, async () => {
-          const balance = await USDC.balanceOf(caller.address);
-          expect(balance).to.equal(0);
-        });
-        then(`proxy has no 'from' token left`, async () => {
-          const balance = await WETH.balanceOf(swapProxy.address);
-          expect(balance).to.equal(0);
-        });
-        then(`proxy has no 'to' token left`, async () => {
-          const balance = await USDC.balanceOf(swapProxy.address);
-          expect(balance).to.equal(0);
-        });
-        then(`recipient has no 'from' token`, async () => {
-          const balance = await WETH.balanceOf(recipient.address);
-          expect(balance).to.equal(0);
-        });
-        then(`recipient has the expected amount of 'to' token`, async () => {
-          const balance = await USDC.balanceOf(recipient.address);
-          validateResult(balance);
-        });
+        then(`caller has no 'to' token`, () => expectBalanceToBeEmpty(USDC, caller));
+        then(`proxy has no 'from' token left`, () => expectBalanceToBeEmpty(WETH, swapProxy));
+        then(`proxy has no 'to' token left`, () => expectBalanceToBeEmpty(USDC, swapProxy));
+        then(`recipient has no 'from' token`, () => expectBalanceToBeEmpty(WETH, recipient));
+        then(`recipient has the expected amount of 'to' token`, () => expectBalanceToBeGreatherThan(USDC, minAmountOut, recipient));
       });
-
-      function validateResult(result: BigNumber) {
-        expect(result.gte(minAmountOut)).to.be.true;
-      }
-
-      const PRECISION = 10000;
-      function calculatePercentage(amount: BigNumber, percentage: number) {
-        const numerator = amount.mul(Math.round((percentage * PRECISION) / 100));
-        return numerator.mod(PRECISION).isZero() ? numerator.div(PRECISION) : numerator.div(PRECISION).add(1); // Round up
-      }
     });
-  }
-
-  const DETERMINISTIC_FACTORY_ADMIN = '0x1a00e1e311009e56e3b0b9ed6f86f5ce128a1c01';
-  const DEPLOYER_ROLE = utils.keccak256(utils.toUtf8Bytes('DEPLOYER_ROLE'));
-  async function fork({ chain, chainId, deployer }: { chain: string; chainId: number; deployer: SignerWithAddress }): Promise<void> {
-    // Set fork of network
-    await evm.reset({
-      jsonRpcUrl: getNodeUrl(chain),
-    });
-    setTestChainId(chainId);
-    // Give deployer role to our deployer address
-    const admin = await wallet.impersonate(DETERMINISTIC_FACTORY_ADMIN);
-    await wallet.setBalance({ account: admin._address, balance: constants.MaxUint256 });
-    const deterministicFactory = await ethers.getContractAt<DeterministicFactory>(
-      DeterministicFactory__factory.abi,
-      '0xbb681d77506df5CA21D2214ab3923b4C056aa3e2'
-    );
-    await deterministicFactory.connect(admin).grantRole(DEPLOYER_ROLE, deployer.address);
   }
 });

--- a/test/integration/take-and-run-swap.spec.ts
+++ b/test/integration/take-and-run-swap.spec.ts
@@ -1,0 +1,96 @@
+import { ethers } from 'hardhat';
+import { contract, given, then, when } from '@utils/bdd';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { JsonRpcSigner } from '@ethersproject/providers';
+import { IERC20, SwapperRegistry, SwapProxy } from '@typechained';
+import { BigNumber, utils } from 'ethers';
+import { snapshot } from '@utils/evm';
+import { deployContractsAndReturnSigners, ETH_ADDRESS, getQuoteAndAllowlistSwapper } from './utils';
+import { expectBalanceToBeEmpty, expectBalanceToBeGreatherThan, expectETHBalanceToBeEmpty } from './assertions';
+import { paraswapAdapter } from './dex-adapters';
+
+contract('SwapProxy', () => {
+  let registry: SwapperRegistry;
+  let swapProxy: SwapProxy;
+  let WETH: IERC20, USDC: IERC20;
+  let wethWhale: JsonRpcSigner;
+  let caller: SignerWithAddress, recipient: SignerWithAddress;
+  let snapshotId: string;
+
+  before(async () => {
+    ({ registry, swapProxy, WETH, USDC, wethWhale } = await deployContractsAndReturnSigners());
+    [caller, recipient] = await ethers.getSigners();
+    snapshotId = await snapshot.take();
+  });
+
+  beforeEach(async () => {
+    await snapshot.revert(snapshotId);
+  });
+
+  describe('takeAndRunSwap', () => {
+    when('executing with ETH as token in', () => {
+      let minAmountOut: BigNumber;
+      given(async () => {
+        const quote = await getQuoteAndAllowlistSwapper({
+          swapProxy,
+          registry,
+          tokenIn: 'ETH',
+          tokenOut: USDC,
+          trade: 'sell',
+          amount: utils.parseEther('0.5'),
+          recipient: recipient,
+          quoter: paraswapAdapter,
+        });
+        await swapProxy.connect(caller).takeAndRunSwap(
+          {
+            swapper: quote.swapperAddress,
+            allowanceTarget: quote.allowanceTarget,
+            swapData: quote.data,
+            tokenIn: ETH_ADDRESS,
+            maxAmountIn: quote.maxAmountIn,
+            checkUnspentTokensIn: false,
+          },
+          { value: utils.parseEther('0.5') }
+        );
+        minAmountOut = quote.minAmountOut;
+      });
+      then(`caller has no 'to' token`, () => expectBalanceToBeEmpty(USDC, caller));
+      then(`proxy has no 'from' token left`, () => expectETHBalanceToBeEmpty(swapProxy));
+      then(`proxy has no 'to' token left`, () => expectBalanceToBeEmpty(USDC, swapProxy));
+      then(`recipient has the expected amount of 'to' token`, () => expectBalanceToBeGreatherThan(USDC, minAmountOut, recipient));
+    });
+
+    when('executing with WETH as token in ', () => {
+      let minAmountOut: BigNumber;
+      given(async () => {
+        const quote = await getQuoteAndAllowlistSwapper({
+          swapProxy,
+          registry,
+          tokenIn: WETH,
+          tokenOut: USDC,
+          trade: 'sell',
+          amount: utils.parseEther('0.5'),
+          recipient: recipient,
+          quoter: paraswapAdapter,
+        });
+        await WETH.connect(wethWhale).transfer(caller.address, quote.maxAmountIn);
+        await WETH.connect(caller).approve(swapProxy.address, quote.maxAmountIn);
+        await swapProxy.connect(caller).takeAndRunSwap({
+          swapper: quote.swapperAddress,
+          allowanceTarget: quote.allowanceTarget,
+          swapData: quote.data,
+          tokenIn: WETH.address,
+          maxAmountIn: quote.maxAmountIn,
+          checkUnspentTokensIn: false,
+        });
+        minAmountOut = quote.minAmountOut;
+      });
+      then(`caller has no 'from' token left`, () => expectBalanceToBeEmpty(WETH, caller));
+      then(`caller has no 'to' token`, () => expectBalanceToBeEmpty(USDC, caller));
+      then(`proxy has no 'from' token left`, () => expectBalanceToBeEmpty(WETH, swapProxy));
+      then(`proxy has no 'to' token left`, () => expectBalanceToBeEmpty(USDC, swapProxy));
+      then(`recipient has no 'from' token`, () => expectBalanceToBeEmpty(WETH, recipient));
+      then(`recipient has the expected amount of 'to' token`, () => expectBalanceToBeGreatherThan(USDC, minAmountOut, recipient));
+    });
+  });
+});

--- a/test/integration/utils.ts
+++ b/test/integration/utils.ts
@@ -1,0 +1,107 @@
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { IERC20, SwapperRegistry, SwapProxy } from '@typechained';
+import { evm, wallet } from '@utils';
+import { BigNumber, BigNumberish, constants, utils } from 'ethers';
+import hre, { deployments, ethers, getNamedAccounts } from 'hardhat';
+import { getNodeUrl } from 'utils/env';
+import { setTestChainId } from 'utils/deploy';
+import { DeterministicFactory, DeterministicFactory__factory } from '@mean-finance/deterministic-factory/typechained';
+import { QuoteInput, Quote } from './dex-adapters';
+import { abi as IERC20_ABI } from '@openzeppelin/contracts/build/contracts/IERC20.json';
+
+export const ETH_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
+const CHAIN = { chain: 'ethereum', chainId: 1 };
+const WETH_ADDRESS = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
+const WETH_WHALE_ADDRESS = '0xf04a5cc80b1e94c69b48f5ee68a08cd2f09a7c3e';
+const USDC_ADDRESS = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+
+export async function getQuoteAndAllowlistSwapper({
+  swapProxy,
+  registry,
+  tokenIn,
+  tokenOut,
+  slippagePercentage,
+  trade,
+  amount,
+  quoter,
+  recipient,
+}: {
+  swapProxy: SwapProxy;
+  registry: SwapperRegistry;
+  tokenIn: IERC20 | 'ETH';
+  tokenOut: IERC20;
+  slippagePercentage?: number;
+  amount: BigNumberish;
+  trade: 'sell' | 'buy';
+  quoter: (input: QuoteInput) => Promise<Quote>;
+  recipient?: SignerWithAddress;
+}) {
+  const slippage = slippagePercentage ?? 0.3;
+  const quote = await quoter({
+    tokenIn: tokenIn == 'ETH' ? ETH_ADDRESS : tokenIn.address,
+    tokenOut: tokenOut.address,
+    chainId: 1,
+    slippagePercentage: slippage,
+    amount,
+    userAddress: swapProxy.address,
+    trade,
+    recipient: recipient?.address,
+  });
+  const amountIn = BigNumber.from(quote.amountIn);
+  const amountOut = BigNumber.from(quote.amountOut);
+  let maxAmountIn: BigNumber, minAmountOut: BigNumber;
+  if (trade === 'sell') {
+    maxAmountIn = amountIn;
+    minAmountOut = amountOut.sub(calculatePercentage(amountOut, slippage));
+  } else {
+    maxAmountIn = amountIn.add(calculatePercentage(amountIn, slippage));
+    minAmountOut = amountOut;
+  }
+  const { admin: adminAddress } = await getNamedAccounts();
+  const admin = await wallet.impersonate(adminAddress);
+  await ethers.provider.send('hardhat_setBalance', [adminAddress, '0xffffffffffffffff']);
+  await registry.connect(admin).allowSwappers([quote.swapperAddress]);
+  if (quote.allowanceTarget !== quote.swapperAddress) {
+    await registry.connect(admin).allowSupplementaryAllowanceTargets([quote.allowanceTarget]);
+  }
+  return { ...quote, maxAmountIn, minAmountOut };
+}
+
+export async function deployContractsAndReturnSigners() {
+  await fork({ ...CHAIN });
+  await deployments.fixture(['SwapProxy'], { keepExistingDeployments: false });
+  const registry = await ethers.getContract<SwapperRegistry>('SwapperRegistry');
+  const swapProxy = await ethers.getContract<SwapProxy>('SwapProxy');
+  const WETH = await ethers.getContractAt<IERC20>(IERC20_ABI, WETH_ADDRESS);
+  const USDC = await ethers.getContractAt<IERC20>(IERC20_ABI, USDC_ADDRESS);
+
+  const wethWhale = await wallet.impersonate(WETH_WHALE_ADDRESS);
+  await wallet.setBalance({ account: WETH_WHALE_ADDRESS, balance: BigNumber.from('0xffffffffffffffff') });
+  return { registry, swapProxy, WETH, USDC, wethWhale };
+}
+
+const DETERMINISTIC_FACTORY_ADMIN = '0x1a00e1e311009e56e3b0b9ed6f86f5ce128a1c01';
+const DEPLOYER_ROLE = utils.keccak256(utils.toUtf8Bytes('DEPLOYER_ROLE'));
+export async function fork({ chain, chainId }: { chain: string; chainId: number }): Promise<void> {
+  // Set fork of network
+  await evm.reset({
+    jsonRpcUrl: getNodeUrl(chain),
+  });
+  setTestChainId(chainId);
+  // Give deployer role to our deployer address
+  const admin = await wallet.impersonate(DETERMINISTIC_FACTORY_ADMIN);
+  await wallet.setBalance({ account: admin._address, balance: constants.MaxUint256 });
+  const deterministicFactory = await ethers.getContractAt<DeterministicFactory>(
+    DeterministicFactory__factory.abi,
+    '0xbb681d77506df5CA21D2214ab3923b4C056aa3e2'
+  );
+  const { deployer: deployerAddress } = await hre.getNamedAccounts();
+  const deployer = await ethers.getSigner(deployerAddress);
+  await deterministicFactory.connect(admin).grantRole(DEPLOYER_ROLE, deployer.address);
+}
+
+const PRECISION = 10000;
+function calculatePercentage(amount: BigNumber, percentage: number) {
+  const numerator = amount.mul(Math.round((percentage * PRECISION) / 100));
+  return numerator.mod(PRECISION).isZero() ? numerator.div(PRECISION) : numerator.div(PRECISION).add(1); // Round up
+}


### PR DESCRIPTION
We are now simply adding a new integration test for `takeAndRunSwap`. However, we extracted a lot of logic from the already existing integration test so that we could use it for this and future tests