### PR TITLE
refactor: add collectable dust to swap adapter

### DIFF
--- a/solidity/contracts/SwapAdapter.sol
+++ b/solidity/contracts/SwapAdapter.sol
@@ -3,17 +3,16 @@ pragma solidity >=0.8.7 <0.9.0;
 
 import '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
 import '@openzeppelin/contracts/utils/Address.sol';
+import './utils/CollectableDust.sol';
 import '../interfaces/ISwapAdapter.sol';
 
-address constant PROTOCOL_TOKEN = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
-
-abstract contract SwapAdapter is ISwapAdapter {
+abstract contract SwapAdapter is ISwapAdapter, CollectableDust {
   using SafeERC20 for IERC20;
   using Address for address;
 
   ISwapperRegistry public immutable SWAPPER_REGISTRY;
 
-  constructor(address _swapperRegistry) {
+  constructor(address _swapperRegistry, address _governor) Governable(_governor) {
     if (_swapperRegistry == address(0)) revert ZeroAddress();
     SWAPPER_REGISTRY = ISwapperRegistry(_swapperRegistry);
   }

--- a/solidity/contracts/SwapProxy.sol
+++ b/solidity/contracts/SwapProxy.sol
@@ -6,7 +6,6 @@ import './extensions/TakeRunSwapAndTransfer.sol';
 import './extensions/TakeRunSwapsAndTransferMany.sol';
 import './extensions/TakeManyRunSwapAndTransferMany.sol';
 import './extensions/TakeManyRunSwapsAndTransferMany.sol';
-import './utils/CollectableDust.sol';
 
 /**
  * @notice This contract implements all swap extensions, so it can be used by EOAs or other contracts that do not have the extensions
@@ -16,8 +15,7 @@ contract SwapProxy is
   TakeRunSwapAndTransfer,
   TakeRunSwapsAndTransferMany,
   TakeManyRunSwapAndTransferMany,
-  TakeManyRunSwapsAndTransferMany,
-  CollectableDust
+  TakeManyRunSwapsAndTransferMany
 {
-  constructor(address _swapperRegistry, address _governor) SwapAdapter(_swapperRegistry) Governable(_governor) {}
+  constructor(address _swapperRegistry, address _governor) SwapAdapter(_swapperRegistry, _governor) {}
 }

--- a/solidity/contracts/test/Extensions.sol
+++ b/solidity/contracts/test/Extensions.sol
@@ -42,7 +42,7 @@ contract Extensions is
   ExecuteSwapCall[] internal _executeSwapCalls;
   SendBalanceToRecipientCall[] internal _sendBalanceToRecipientCalls;
 
-  constructor(address _swapperRegistry) SwapAdapter(_swapperRegistry) {}
+  constructor(address _swapperRegistry) SwapAdapter(_swapperRegistry, address(1)) {}
 
   function takeFromMsgSenderCalls() external view returns (TakeFromMsgSenderCall[] memory) {
     return _takeFromMsgSenderCalls;

--- a/solidity/contracts/test/SwapAdapter.sol
+++ b/solidity/contracts/test/SwapAdapter.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.7 <0.9.0;
 import '../SwapAdapter.sol';
 
 contract SwapAdapterMock is SwapAdapter {
-  constructor(address _swapperRegistry) SwapAdapter(_swapperRegistry) {}
+  constructor(address _swapperRegistry, address _governor) SwapAdapter(_swapperRegistry, _governor) {}
 
   function internalTakeFromMsgSender(IERC20 _token, uint256 _amount) external {
     _takeFromMsgSender(_token, _amount);

--- a/test/unit/swap-adapter.spec.ts
+++ b/test/unit/swap-adapter.spec.ts
@@ -15,7 +15,7 @@ describe('SwapAdapter', () => {
   const ACCOUNT = '0x0000000000000000000000000000000000000001';
   const AMOUNT = 1000000;
 
-  let caller: SignerWithAddress;
+  let caller: SignerWithAddress, governor: SignerWithAddress;
   let swapAdapterFactory: SwapAdapterMock__factory;
   let swapAdapter: SwapAdapterMock;
   let swapper: MockContract<Swapper>;
@@ -24,12 +24,12 @@ describe('SwapAdapter', () => {
   let token: FakeContract<IERC20>;
 
   before('Setup accounts and contracts', async () => {
-    [caller] = await ethers.getSigners();
+    [caller, governor] = await ethers.getSigners();
     registry = await smock.fake('ISwapperRegistry');
     const swapperFactory = await smock.mock<Swapper__factory>('Swapper');
     swapper = await swapperFactory.deploy();
     swapAdapterFactory = await ethers.getContractFactory('solidity/contracts/test/SwapAdapter.sol:SwapAdapterMock');
-    swapAdapter = await swapAdapterFactory.deploy(registry.address);
+    swapAdapter = await swapAdapterFactory.deploy(registry.address, governor.address);
     token = await smock.fake('IERC20');
     snapshotId = await snapshot.take();
   });
@@ -53,7 +53,7 @@ describe('SwapAdapter', () => {
       then('tx is reverted with reason error', async () => {
         await behaviours.deployShouldRevertWithMessage({
           contract: swapAdapterFactory,
-          args: [constants.AddressZero],
+          args: [constants.AddressZero, governor.address],
           message: 'ZeroAddress',
         });
       });


### PR DESCRIPTION
We realized that it made sense that all contracts that implement `SwapAdapter` should also implement `CollectableDust`