### PR TITLE
feat: add collectable extension

### DIFF
--- a/solidity/contracts/extensions/CollectableWithGovernor.sol
+++ b/solidity/contracts/extensions/CollectableWithGovernor.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.8.7 <0.9.0;
+
+import '../utils/Governable.sol';
+import './InternalCollectableDust.sol';
+
+abstract contract CollectableWithGovernor is InternalCollectableDust, Governable {
+  /**
+   * @notice Sends the given token to the recipient
+   * @dev Can only be called by the governor
+   * @param _token The token to send to the recipient (can be an ERC20 or the protocol token)
+   * @param _amount The amount to transfer to the recipient
+   * @param _recipient The address of the recipient
+   */
+  function sendDust(
+    address _token,
+    uint256 _amount,
+    address _recipient
+  ) external onlyGovernor {
+    _sendDust(_token, _amount, _recipient);
+  }
+}

--- a/solidity/contracts/extensions/InternalCollectableDust.sol
+++ b/solidity/contracts/extensions/InternalCollectableDust.sol
@@ -35,7 +35,7 @@ abstract contract InternalCollectableDust is SwapAdapter {
     address _token,
     uint256 _amount,
     address _recipient
-  ) internal {
+  ) internal virtual {
     if (_recipient == address(0)) revert DustRecipientIsZeroAddress();
     if (_token == PROTOCOL_TOKEN) {
       payable(_recipient).sendValue(_amount);

--- a/test/unit/extensions/assertions.ts
+++ b/test/unit/extensions/assertions.ts
@@ -86,3 +86,17 @@ export function thenRevokeWasCalledCorrectly(args: () => { contract: Extensions;
     }
   });
 }
+
+export function thenSendDustWasCalledCorrectly(
+  args: () => { contract: Extensions; calls: { token: string; amount: BigNumberish; recipient: string }[] }
+) {
+  then('send dust was called correctly', async () => {
+    const { contract, calls: expectedCalls } = args();
+    const calls = await contract.sendDustCalls();
+    for (let i = 0; i < calls.length; i++) {
+      expect(calls[i].token).to.equal(expectedCalls[i].token);
+      expect(calls[i].amount).to.equal(expectedCalls[i].amount);
+      expect(calls[i].recipient).to.equal(expectedCalls[i].recipient);
+    }
+  });
+}

--- a/test/unit/extensions/collectable-with-governor.spec.ts
+++ b/test/unit/extensions/collectable-with-governor.spec.ts
@@ -1,0 +1,52 @@
+import chai from 'chai';
+import { ethers } from 'hardhat';
+import { contract, given, when } from '@utils/bdd';
+import { Extensions, Extensions__factory, IERC20 } from '@typechained';
+import { snapshot } from '@utils/evm';
+import { FakeContract, smock } from '@defi-wonderland/smock';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { thenSendDustWasCalledCorrectly } from './assertions';
+import { behaviours } from '@utils';
+
+chai.use(smock.matchers);
+
+contract('CollectableWithGovernor', () => {
+  const ACCOUNT = '0x0000000000000000000000000000000000000001';
+  const AMOUNT = 100000;
+
+  let governor: SignerWithAddress;
+  let extensions: Extensions;
+  let token: FakeContract<IERC20>;
+  let snapshotId: string;
+
+  before('Setup accounts and contracts', async () => {
+    [, governor] = await ethers.getSigners();
+    token = await smock.fake('IERC20');
+    const factory: Extensions__factory = await ethers.getContractFactory('solidity/contracts/test/Extensions.sol:Extensions');
+    extensions = await factory.deploy(ACCOUNT, governor.address);
+    snapshotId = await snapshot.take();
+  });
+
+  beforeEach(async () => {
+    await snapshot.revert(snapshotId);
+    token.transfer.returns(true);
+  });
+
+  describe('sendDust', () => {
+    when('function is called', () => {
+      given(async () => {
+        await extensions.connect(governor).sendDust(token.address, AMOUNT, ACCOUNT);
+      });
+      thenSendDustWasCalledCorrectly(() => ({
+        contract: extensions,
+        calls: [{ token: token.address, amount: AMOUNT, recipient: ACCOUNT }],
+      }));
+    });
+    behaviours.shouldBeExecutableOnlyByGovernor({
+      contract: () => extensions,
+      funcAndSignature: 'sendDust',
+      params: () => [token.address, AMOUNT, ACCOUNT],
+      governor: () => governor,
+    });
+  });
+});


### PR DESCRIPTION
We are now creating a new extension called `sendDust`. This extension will allow the governor to transfer any remaining tokens from the contract, to a given recipient