### PR TITLE
feat: run swap extension

### DIFF
--- a/deploy/001_swapper_registry.ts
+++ b/deploy/001_swapper_registry.ts
@@ -1,5 +1,5 @@
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
-import { SwapperRegistry__factory } from '@typechained';
+import { bytecode } from '../artifacts/solidity/contracts/SwapperRegistry.sol/SwapperRegistry.json';
 import { deployThroughDeterministicFactory } from '@mean-finance/deterministic-factory/utils/deployment';
 import { DeployFunction } from '@0xged/hardhat-deploy/dist/types';
 
@@ -11,7 +11,7 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
     name: 'SwapperRegistry',
     salt: 'MF-Swapper-Registry-V1',
     contract: 'solidity/contracts/SwapperRegistry.sol:SwapperRegistry',
-    bytecode: SwapperRegistry__factory.bytecode,
+    bytecode,
     constructorArgs: {
       types: ['address[]', 'address[]', 'address', 'address[]'],
       values: [[], [], superAdmin, [superAdmin]],

--- a/deploy/002_swap_proxy.ts
+++ b/deploy/002_swap_proxy.ts
@@ -1,5 +1,5 @@
 import { HardhatRuntimeEnvironment } from 'hardhat/types';
-import { SwapProxy__factory } from '@typechained';
+import { bytecode } from '../artifacts/solidity/contracts/SwapProxy.sol/SwapProxy.json';
 import { deployThroughDeterministicFactory } from '@mean-finance/deterministic-factory/utils/deployment';
 import { DeployFunction } from '@0xged/hardhat-deploy/dist/types';
 
@@ -13,7 +13,7 @@ const deployFunction: DeployFunction = async function (hre: HardhatRuntimeEnviro
     name: 'SwapProxy',
     salt: 'MF-Swap-Proxy-V1',
     contract: 'solidity/contracts/SwapProxy.sol:SwapProxy',
-    bytecode: SwapProxy__factory.bytecode,
+    bytecode,
     constructorArgs: {
       types: ['address', 'address'],
       values: [registry.address, admin],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mean-finance/swappers",
-  "version": "1.0.0-rc1",
+  "version": "1.0.0-rc2",
   "description": "Mean Swappers",
   "keywords": [
     "ethereum",

--- a/solidity/contracts/extensions/RunSwap.sol
+++ b/solidity/contracts/extensions/RunSwap.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.8.7 <0.9.0;
+
+import '../SwapAdapter.sol';
+
+abstract contract RunSwap is SwapAdapter {
+  /// @notice The parameters to execute the call
+  struct RunSwapParams {
+    // The swapper that will execute the call
+    address swapper;
+    // The account that needs to be approved for token transfers
+    address allowanceTarget;
+    // The actual swap execution
+    bytes swapData;
+    // The token that will be swapped
+    address tokenIn;
+    // The amount of "token in" that will be spent
+    uint256 amountIn;
+  }
+
+  /**
+   * @notice Executes a swap with the given swapper. The input tokens are expected to be on the contract before
+   *         this function is executed. If the swap doesn't include a transfer, then the swapped tokens will be left
+   *         on the contract
+   * @dev This function can only be executed with swappers that are allowlisted
+   * @param _parameters The parameters for the swap
+   */
+  function runSwap(RunSwapParams calldata _parameters) external payable onlyAllowlisted(_parameters.swapper) {
+    if (_parameters.tokenIn == PROTOCOL_TOKEN) {
+      _executeSwap(_parameters.swapper, _parameters.swapData, _parameters.amountIn);
+    } else {
+      _maxApproveSpenderIfNeeded(
+        IERC20(_parameters.tokenIn),
+        _parameters.allowanceTarget,
+        _parameters.swapper == _parameters.allowanceTarget, // If target is a swapper, then it's ok as allowance target
+        _parameters.amountIn
+      );
+      _executeSwap(_parameters.swapper, _parameters.swapData, 0);
+    }
+  }
+}

--- a/solidity/contracts/test/Extensions.sol
+++ b/solidity/contracts/test/Extensions.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.7 <0.9.0;
 
+import '../extensions/RunSwap.sol';
 import '../extensions/TakeAndRunSwap.sol';
 import '../extensions/TakeRunSwapAndTransfer.sol';
 import '../extensions/TakeRunSwapsAndTransferMany.sol';
@@ -12,6 +13,7 @@ import '../extensions/RevokableWithGovernor.sol';
 import '../extensions/CollectableWithGovernor.sol';
 
 contract Extensions is
+  RunSwap,
   TakeAndRunSwap,
   TakeRunSwapAndTransfer,
   TakeRunSwapsAndTransferMany,

--- a/test/unit/extensions/run-swap.spec.ts
+++ b/test/unit/extensions/run-swap.spec.ts
@@ -1,0 +1,119 @@
+import chai from 'chai';
+import { ethers } from 'hardhat';
+import { contract, given, when } from '@utils/bdd';
+import { Extensions, Extensions__factory, IERC20, ISwapperRegistry, Swapper } from '@typechained';
+import { snapshot } from '@utils/evm';
+import { FakeContract, smock } from '@defi-wonderland/smock';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { thenMaxApproveSpenderIsCalledCorrectly, thenExecuteSwapIsCalledCorrectly, thenAllowlistWasCheckedForSwappers } from './assertions';
+
+chai.use(smock.matchers);
+
+contract('RunSwap', () => {
+  const ACCOUNT = '0x0000000000000000000000000000000000000001';
+  const AMOUNT = 1000000;
+
+  let caller: SignerWithAddress;
+  let extensions: Extensions;
+  let swapper: FakeContract<Swapper>;
+  let registry: FakeContract<ISwapperRegistry>;
+  let token: FakeContract<IERC20>;
+  let swapData: string;
+  let snapshotId: string;
+
+  before('Setup accounts and contracts', async () => {
+    [caller] = await ethers.getSigners();
+    registry = await smock.fake('ISwapperRegistry');
+    swapper = await smock.fake('ISwapper');
+    token = await smock.fake('IERC20');
+    const factory: Extensions__factory = await ethers.getContractFactory('solidity/contracts/test/Extensions.sol:Extensions');
+    extensions = await factory.deploy(registry.address, ACCOUNT);
+    const { data } = await swapper.populateTransaction.executeSwap(ACCOUNT, ACCOUNT, AMOUNT);
+    swapData = data!;
+    snapshotId = await snapshot.take();
+  });
+
+  beforeEach(async () => {
+    await snapshot.revert(snapshotId);
+    token.transfer.returns(true);
+    token.transferFrom.returns(true);
+    registry.isSwapperAllowlisted.reset();
+    registry.isSwapperAllowlisted.returns(true);
+    registry.isValidAllowanceTarget.returns(true);
+  });
+
+  describe('runSwap', () => {
+    when('token is ERC20', () => {
+      given(async () => {
+        await extensions.runSwap({
+          swapper: swapper.address,
+          allowanceTarget: ACCOUNT,
+          swapData: swapData,
+          tokenIn: token.address,
+          amountIn: AMOUNT,
+        });
+      });
+      thenAllowlistWasCheckedForSwappers(() => ({
+        registry,
+        swappers: [swapper.address],
+      }));
+      thenMaxApproveSpenderIsCalledCorrectly(() => ({
+        contract: extensions,
+        calls: [{ token: token.address, spender: ACCOUNT, alreadyValidatedSpender: false, minAllowance: AMOUNT }],
+      }));
+      thenExecuteSwapIsCalledCorrectly(() => ({
+        contract: extensions,
+        calls: [{ swapper: swapper.address, swapData, value: 0 }],
+      }));
+    });
+    when('token is ERC20 and allowance target is the same as the swapper', () => {
+      given(async () => {
+        await extensions.runSwap({
+          swapper: swapper.address,
+          allowanceTarget: swapper.address,
+          swapData: swapData,
+          tokenIn: token.address,
+          amountIn: AMOUNT,
+        });
+      });
+      thenAllowlistWasCheckedForSwappers(() => ({
+        registry,
+        swappers: [swapper.address],
+      }));
+      thenMaxApproveSpenderIsCalledCorrectly(() => ({
+        contract: extensions,
+        calls: [{ token: token.address, spender: swapper.address, alreadyValidatedSpender: true, minAllowance: AMOUNT }],
+      }));
+      thenExecuteSwapIsCalledCorrectly(() => ({
+        contract: extensions,
+        calls: [{ swapper: swapper.address, swapData, value: 0 }],
+      }));
+    });
+    when('token in is protocol token', () => {
+      given(async () => {
+        await extensions.runSwap(
+          {
+            swapper: swapper.address,
+            allowanceTarget: ACCOUNT,
+            swapData: swapData,
+            tokenIn: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+            amountIn: AMOUNT,
+          },
+          { value: AMOUNT }
+        );
+      });
+      thenAllowlistWasCheckedForSwappers(() => ({
+        registry,
+        swappers: [swapper.address],
+      }));
+      thenMaxApproveSpenderIsCalledCorrectly(() => ({
+        contract: extensions,
+        calls: [],
+      }));
+      thenExecuteSwapIsCalledCorrectly(() => ({
+        contract: extensions,
+        calls: [{ swapper: swapper.address, swapData, value: AMOUNT }],
+      }));
+    });
+  });
+});


### PR DESCRIPTION
We are now adding a new extension called `RunSwap`. This extensions is meant to add swap capabilities that can be easily add as part of a multicall. That's why it assumes that the tokens are already on the contract