### PR TITLE
refactor: check zero address

### DIFF
--- a/solidity/contracts/SwapAdapter.sol
+++ b/solidity/contracts/SwapAdapter.sol
@@ -75,7 +75,8 @@ abstract contract SwapAdapter is ISwapAdapter {
    * @param _token The token to check
    * @param _recipient The recipient of the token balance
    */
-  function _sendBalanceToRecipient(address _token, address _recipient) internal virtual {
+  function _sendBalanceOnContractToRecipient(address _token, address _recipient) internal virtual {
+    if (_recipient == address(0)) revert ZeroAddress();
     if (_token == PROTOCOL_TOKEN) {
       uint256 _balance = address(this).balance;
       if (_balance > 0) {

--- a/solidity/contracts/extensions/TakeAndRunSwap.sol
+++ b/solidity/contracts/extensions/TakeAndRunSwap.sol
@@ -38,7 +38,7 @@ abstract contract TakeAndRunSwap is SwapAdapter {
     }
     _executeSwap(_parameters.swapper, _parameters.swapData, msg.value);
     if (_parameters.checkUnspentTokensIn) {
-      _sendBalanceToRecipient(_parameters.tokenIn, msg.sender);
+      _sendBalanceOnContractToRecipient(_parameters.tokenIn, msg.sender);
     }
   }
 }

--- a/solidity/contracts/extensions/TakeManyRunSwapAndTransferMany.sol
+++ b/solidity/contracts/extensions/TakeManyRunSwapAndTransferMany.sol
@@ -50,7 +50,7 @@ abstract contract TakeManyRunSwapAndTransferMany is SwapAdapter {
     // Transfer out whatever was left in the contract
     for (uint256 i; i < _parameters.transferOutBalance.length; i++) {
       TransferOutBalance memory _transferOutBalance = _parameters.transferOutBalance[i];
-      _sendBalanceToRecipient(_transferOutBalance.token, _transferOutBalance.recipient);
+      _sendBalanceOnContractToRecipient(_transferOutBalance.token, _transferOutBalance.recipient);
     }
   }
 }

--- a/solidity/contracts/extensions/TakeManyRunSwapsAndTransferMany.sol
+++ b/solidity/contracts/extensions/TakeManyRunSwapsAndTransferMany.sol
@@ -56,7 +56,7 @@ abstract contract TakeManyRunSwapsAndTransferMany is SwapAdapter {
     // Transfer out whatever was left in the contract
     for (uint256 i; i < _parameters.transferOutBalance.length; i++) {
       TransferOutBalance memory _transferOutBalance = _parameters.transferOutBalance[i];
-      _sendBalanceToRecipient(_transferOutBalance.token, _transferOutBalance.recipient);
+      _sendBalanceOnContractToRecipient(_transferOutBalance.token, _transferOutBalance.recipient);
     }
   }
 }

--- a/solidity/contracts/extensions/TakeRunSwapAndTransfer.sol
+++ b/solidity/contracts/extensions/TakeRunSwapAndTransfer.sol
@@ -47,8 +47,8 @@ abstract contract TakeRunSwapAndTransfer is SwapAdapter {
     }
     _executeSwap(_parameters.swapper, _parameters.swapData, msg.value);
     if (_parameters.checkUnspentTokensIn) {
-      _sendBalanceToRecipient(_parameters.tokenIn, msg.sender);
+      _sendBalanceOnContractToRecipient(_parameters.tokenIn, msg.sender);
     }
-    _sendBalanceToRecipient(_parameters.tokenOut, _parameters.recipient);
+    _sendBalanceOnContractToRecipient(_parameters.tokenOut, _parameters.recipient);
   }
 }

--- a/solidity/contracts/extensions/TakeRunSwapsAndTransferMany.sol
+++ b/solidity/contracts/extensions/TakeRunSwapsAndTransferMany.sol
@@ -57,7 +57,7 @@ abstract contract TakeRunSwapsAndTransferMany is SwapAdapter {
     // Transfer out whatever was left in the contract
     for (uint256 i; i < _parameters.transferOutBalance.length; i++) {
       TransferOutBalance memory _transferOutBalance = _parameters.transferOutBalance[i];
-      _sendBalanceToRecipient(_transferOutBalance.token, _transferOutBalance.recipient);
+      _sendBalanceOnContractToRecipient(_transferOutBalance.token, _transferOutBalance.recipient);
     }
   }
 }

--- a/solidity/contracts/test/Extensions.sol
+++ b/solidity/contracts/test/Extensions.sol
@@ -42,7 +42,7 @@ contract Extensions is
     uint256 value;
   }
 
-  struct SendBalanceToRecipientCall {
+  struct SendBalanceOnContractToRecipientCall {
     address token;
     address recipient;
   }
@@ -56,7 +56,7 @@ contract Extensions is
   TakeFromMsgSenderCall[] internal _takeFromMsgSenderCalls;
   MaxApproveSpenderCall[] internal _maxApproveSpenderCalls;
   ExecuteSwapCall[] internal _executeSwapCalls;
-  SendBalanceToRecipientCall[] internal _sendBalanceToRecipientCalls;
+  SendBalanceOnContractToRecipientCall[] internal _sendBalanceOnContractToRecipientCalls;
   RevokeAction[][] internal _revokeCalls;
   SendDustCall[] internal _sendDustCalls;
 
@@ -74,8 +74,8 @@ contract Extensions is
     return _executeSwapCalls;
   }
 
-  function sendBalanceToRecipientCalls() external view returns (SendBalanceToRecipientCall[] memory) {
-    return _sendBalanceToRecipientCalls;
+  function sendBalanceOnContractToRecipientCalls() external view returns (SendBalanceOnContractToRecipientCall[] memory) {
+    return _sendBalanceOnContractToRecipientCalls;
   }
 
   function revokeAllowancesCalls() external view returns (RevokeAction[][] memory) {
@@ -110,9 +110,9 @@ contract Extensions is
     super._executeSwap(_swapper, _swapData, _value);
   }
 
-  function _sendBalanceToRecipient(address _token, address _recipient) internal override {
-    _sendBalanceToRecipientCalls.push(SendBalanceToRecipientCall(_token, _recipient));
-    super._sendBalanceToRecipient(_token, _recipient);
+  function _sendBalanceOnContractToRecipient(address _token, address _recipient) internal override {
+    _sendBalanceOnContractToRecipientCalls.push(SendBalanceOnContractToRecipientCall(_token, _recipient));
+    super._sendBalanceOnContractToRecipient(_token, _recipient);
   }
 
   function internalSendDust(

--- a/solidity/contracts/test/SwapAdapter.sol
+++ b/solidity/contracts/test/SwapAdapter.sol
@@ -27,8 +27,8 @@ contract SwapAdapterMock is SwapAdapter {
     _executeSwap(_swapper, _swapData, _value);
   }
 
-  function internalSendBalanceToRecipient(address _token, address _recipient) external {
-    _sendBalanceToRecipient(_token, _recipient);
+  function internalSendBalanceOnContractToRecipient(address _token, address _recipient) external {
+    _sendBalanceOnContractToRecipient(_token, _recipient);
   }
 
   function internalRevokeAllowances(RevokeAction[] calldata _revokeActions) external {

--- a/test/unit/extensions/assertions.ts
+++ b/test/unit/extensions/assertions.ts
@@ -47,9 +47,9 @@ export function thenExecuteSwapIsCalledCorrectly(
 export function thenSendBalanceToRecipientIsCalledCorrectly(
   args: () => { contract: Extensions; calls: { token: string; recipient: string }[] }
 ) {
-  then('_sendBalanceToRecipient is called correctly', async () => {
+  then('_sendBalanceOnContractToRecipient is called correctly', async () => {
     const { contract, calls: expectedCalls } = args();
-    const calls = await contract.sendBalanceToRecipientCalls();
+    const calls = await contract.sendBalanceOnContractToRecipientCalls();
     for (let i = 0; i < calls.length; i++) {
       expect(calls[i].token).to.equal(expectedCalls[i].token);
       expect(calls[i].recipient).to.equal(expectedCalls[i].recipient);
@@ -58,8 +58,8 @@ export function thenSendBalanceToRecipientIsCalledCorrectly(
 }
 
 export function thenSendBalanceToRecipientIsNotCalled(contract: () => Extensions) {
-  then('_sendBalanceToRecipient is not called', async () => {
-    const calls = await contract().sendBalanceToRecipientCalls();
+  then('_sendBalanceOnContractToRecipient is not called', async () => {
+    const calls = await contract().sendBalanceOnContractToRecipientCalls();
     expect(calls).to.have.lengthOf(0);
   });
 }

--- a/test/unit/swap-adapter.spec.ts
+++ b/test/unit/swap-adapter.spec.ts
@@ -195,12 +195,22 @@ describe('SwapAdapter', () => {
     });
   });
 
-  describe('_sendBalanceToRecipient', () => {
+  describe('_sendBalanceOnContractToRecipient', () => {
+    when('recipient is zero address', () => {
+      then('reverts with message', async () => {
+        await behaviours.txShouldRevertWithMessage({
+          contract: swapAdapter,
+          func: 'internalSendBalanceOnContractToRecipient',
+          args: [token.address, constants.AddressZero],
+          message: 'ZeroAddress',
+        });
+      });
+    });
     describe('ERC20', () => {
       when('there is no balance', () => {
         given(async () => {
           token.balanceOf.returns(0);
-          await swapAdapter.internalSendBalanceToRecipient(token.address, ACCOUNT);
+          await swapAdapter.internalSendBalanceOnContractToRecipient(token.address, ACCOUNT);
         });
         then('balance is checked correctly', () => {
           expect(token.balanceOf).to.have.been.calledOnceWith(swapAdapter.address);
@@ -212,7 +222,7 @@ describe('SwapAdapter', () => {
       when('there is some balance', () => {
         given(async () => {
           token.balanceOf.returns(AMOUNT);
-          await swapAdapter.internalSendBalanceToRecipient(token.address, ACCOUNT);
+          await swapAdapter.internalSendBalanceOnContractToRecipient(token.address, ACCOUNT);
         });
         then('balance is checked correctly', () => {
           expect(token.balanceOf).to.have.been.calledOnceWith(swapAdapter.address);
@@ -226,7 +236,7 @@ describe('SwapAdapter', () => {
       const RECIPIENT = Wallet.createRandom();
       when('there is no balance', () => {
         given(async () => {
-          await swapAdapter.internalSendBalanceToRecipient(token.address, RECIPIENT.address);
+          await swapAdapter.internalSendBalanceOnContractToRecipient(token.address, RECIPIENT.address);
         });
         then('nothing is sent', async () => {
           expect(await ethers.provider.getBalance(RECIPIENT.address)).to.equal(0);
@@ -236,7 +246,7 @@ describe('SwapAdapter', () => {
         const BALANCE = BigNumber.from(12345);
         given(async () => {
           await wallet.setBalance({ account: swapAdapter.address, balance: BALANCE });
-          await swapAdapter.internalSendBalanceToRecipient('0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE', RECIPIENT.address);
+          await swapAdapter.internalSendBalanceOnContractToRecipient('0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE', RECIPIENT.address);
         });
         then('adapter no longer has balance', async () => {
           expect(await ethers.provider.getBalance(swapAdapter.address)).to.equal(0);


### PR DESCRIPTION
We are doing two things here:
1. We are renaming `_sendBalanceToRecipient` to `_sendBalanceOnContractToRecipient`, to be consistent with the naming on other repositories
2. We are checking that the recipient is not the zero address. I think that this check will add almost no gas, and it can prevent some uncomfortable situations