### PR TITLE
refactor: avoid msg value

### DIFF
--- a/solidity/contracts/extensions/TakeAndRunSwap.sol
+++ b/solidity/contracts/extensions/TakeAndRunSwap.sol
@@ -35,8 +35,10 @@ abstract contract TakeAndRunSwap is SwapAdapter {
         _parameters.swapper == _parameters.allowanceTarget, // If target is a swapper, then it's ok as allowance target
         _parameters.maxAmountIn
       );
+      _executeSwap(_parameters.swapper, _parameters.swapData, 0);
+    } else {
+      _executeSwap(_parameters.swapper, _parameters.swapData, _parameters.maxAmountIn);
     }
-    _executeSwap(_parameters.swapper, _parameters.swapData, msg.value);
     if (_parameters.checkUnspentTokensIn) {
       _sendBalanceOnContractToRecipient(_parameters.tokenIn, msg.sender);
     }

--- a/solidity/contracts/extensions/TakeRunSwapAndTransfer.sol
+++ b/solidity/contracts/extensions/TakeRunSwapAndTransfer.sol
@@ -44,8 +44,10 @@ abstract contract TakeRunSwapAndTransfer is SwapAdapter {
         _parameters.swapper == _parameters.allowanceTarget, // If target is a swapper, then it's ok as allowance target
         _parameters.maxAmountIn
       );
+      _executeSwap(_parameters.swapper, _parameters.swapData, 0);
+    } else {
+      _executeSwap(_parameters.swapper, _parameters.swapData, _parameters.maxAmountIn);
     }
-    _executeSwap(_parameters.swapper, _parameters.swapData, msg.value);
     if (_parameters.checkUnspentTokensIn) {
       _sendBalanceOnContractToRecipient(_parameters.tokenIn, msg.sender);
     }

--- a/test/unit/extensions/take-and-run-swap.spec.ts
+++ b/test/unit/extensions/take-and-run-swap.spec.ts
@@ -104,7 +104,8 @@ contract('TakeAndRunSwap', () => {
       }));
       thenExecuteSwapIsCalledCorrectly(() => ({
         contract: extensions,
-        calls: [{ swapper: swapper.address, swapData, value: 10 }],
+        // See that even if msg.value is higher than zero, we set the value to 0
+        calls: [{ swapper: swapper.address, swapData, value: 0 }],
       }));
       thenSendBalanceToRecipientIsCalledCorrectly(() => ({
         contract: extensions,
@@ -113,14 +114,17 @@ contract('TakeAndRunSwap', () => {
     });
     when('token in is protocol token', () => {
       given(async () => {
-        await extensions.takeAndRunSwap({
-          swapper: swapper.address,
-          allowanceTarget: ACCOUNT,
-          swapData: swapData,
-          tokenIn: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
-          maxAmountIn: 0,
-          checkUnspentTokensIn: false,
-        });
+        await extensions.takeAndRunSwap(
+          {
+            swapper: swapper.address,
+            allowanceTarget: ACCOUNT,
+            swapData: swapData,
+            tokenIn: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+            maxAmountIn: 10,
+            checkUnspentTokensIn: false,
+          },
+          { value: 20 }
+        );
       });
       thenTakeFromMsgSenderIsCalledCorrectly(() => ({
         contract: extensions,
@@ -132,7 +136,8 @@ contract('TakeAndRunSwap', () => {
       }));
       thenExecuteSwapIsCalledCorrectly(() => ({
         contract: extensions,
-        calls: [{ swapper: swapper.address, swapData, value: 0 }],
+        // See that even if msg.value is higher, we listen to the amount in
+        calls: [{ swapper: swapper.address, swapData, value: 10 }],
       }));
       thenSendBalanceToRecipientIsNotCalled(() => extensions);
     });

--- a/test/unit/extensions/take-run-swap-and-transfer.spec.ts
+++ b/test/unit/extensions/take-run-swap-and-transfer.spec.ts
@@ -112,7 +112,8 @@ contract('TakeRunSwapAndTransfer', () => {
       }));
       thenExecuteSwapIsCalledCorrectly(() => ({
         contract: extensions,
-        calls: [{ swapper: swapper.address, swapData, value: 123456 }],
+        // See that even if msg.value is higher than zero, we set the value to 0
+        calls: [{ swapper: swapper.address, swapData, value: 0 }],
       }));
       thenSendBalanceToRecipientIsCalledCorrectly(() => ({
         contract: extensions,
@@ -136,7 +137,7 @@ contract('TakeRunSwapAndTransfer', () => {
             tokenOut: tokenOut.address,
             recipient: ACCOUNT,
           },
-          { value: 123456 }
+          { value: 1234567 }
         );
       });
       thenAllowlistWasCheckedForSwappers(() => ({
@@ -153,7 +154,8 @@ contract('TakeRunSwapAndTransfer', () => {
       }));
       thenExecuteSwapIsCalledCorrectly(() => ({
         contract: extensions,
-        calls: [{ swapper: swapper.address, swapData, value: 123456 }],
+        // See that even if msg.value is higher, we listen to the amount in
+        calls: [{ swapper: swapper.address, swapData, value: AMOUNT }],
       }));
       thenSendBalanceToRecipientIsCalledCorrectly(() => ({
         contract: extensions,


### PR DESCRIPTION
We realized that in some cases, we were using `msg.value` for swap extensions. This works fine if the swap call is executed independently, but if it's called in the context of multicall with some ether, then it won't work

So we are now using the parameters to determine the actual ether to send in the swap, instead of using `msg.value`

_Note: we need to make the same change to one more place, but it's a little longer, so we are splitting this in two PRs_