### PR TITLE
refactor: avoid msg value in take many run swap transfer many

### DIFF
--- a/solidity/contracts/extensions/TakeManyRunSwapAndTransferMany.sol
+++ b/solidity/contracts/extensions/TakeManyRunSwapAndTransferMany.sol
@@ -15,6 +15,8 @@ abstract contract TakeManyRunSwapAndTransferMany is SwapAdapter {
     address swapper;
     // The actual swap execution
     bytes swapData;
+    // The amount of value to transfer as part of the swap
+    uint256 valueInSwap;
     // Tokens to transfer after swaps have been executed
     TransferOutBalance[] transferOutBalance;
   }
@@ -45,7 +47,7 @@ abstract contract TakeManyRunSwapAndTransferMany is SwapAdapter {
     _assertSwapperIsAllowlisted(_parameters.swapper);
 
     // Execute swap
-    _executeSwap(_parameters.swapper, _parameters.swapData, msg.value);
+    _executeSwap(_parameters.swapper, _parameters.swapData, _parameters.valueInSwap);
 
     // Transfer out whatever was left in the contract
     for (uint256 i; i < _parameters.transferOutBalance.length; i++) {

--- a/test/integration/take-many-run-swap-and-transfer-many.spec.ts
+++ b/test/integration/take-many-run-swap-and-transfer-many.spec.ts
@@ -53,6 +53,7 @@ contract('SwapProxy', () => {
             swapper: quote.swapperAddress,
             allowanceTarget: quote.allowanceTarget,
             swapData: quote.data,
+            valueInSwap: AMOUNT_ETH,
             transferOutBalance: [{ token: USDC.address, recipient: recipient.address }],
           },
           { value: AMOUNT_ETH }
@@ -87,6 +88,7 @@ contract('SwapProxy', () => {
           swapper: quote.swapperAddress,
           allowanceTarget: quote.allowanceTarget,
           swapData: quote.data,
+          valueInSwap: 0,
           transferOutBalance: [{ token: ETH_ADDRESS, recipient: recipient.address }],
         });
         minAmountOut = quote.minAmountOut;

--- a/test/unit/extensions/take-many-run-swap-and-transfer-many.spec.ts
+++ b/test/unit/extensions/take-many-run-swap-and-transfer-many.spec.ts
@@ -66,6 +66,7 @@ contract('TakeManyRunSwapAndTransferMany', () => {
           allowanceTarget: swapper.address,
           swapper: swapper.address,
           swapData,
+          valueInSwap: 0,
           transferOutBalance: [
             { token: tokenIn2.address, recipient: ACCOUNT },
             { token: tokenOut1.address, recipient: ACCOUNT },
@@ -114,6 +115,7 @@ contract('TakeManyRunSwapAndTransferMany', () => {
             ],
             allowanceTarget: ACCOUNT,
             swapper: swapper.address,
+            valueInSwap: 12340,
             swapData,
             transferOutBalance: [
               { token: tokenIn2.address, recipient: ACCOUNT },
@@ -126,7 +128,8 @@ contract('TakeManyRunSwapAndTransferMany', () => {
       });
       thenExecuteSwapIsCalledCorrectly(() => ({
         contract: extensions,
-        calls: [{ swapper: swapper.address, swapData, value: 12345 }],
+        // See that even if msg.value is higher, we listen to the set parameter
+        calls: [{ swapper: swapper.address, swapData, value: 12340 }],
       }));
     });
   });
@@ -140,6 +143,7 @@ contract('TakeManyRunSwapAndTransferMany', () => {
         allowanceTarget: ACCOUNT,
         swapper: swapper.address,
         swapData,
+        valueInSwap: 0,
         transferOutBalance: [
           { token: tokenIn2.address, recipient: ACCOUNT },
           { token: tokenOut1.address, recipient: ACCOUNT },


### PR DESCRIPTION
Same as #57 but for `takeManyRunSwapAndTransferMany`