### PR TITLE
refactor: set super admin role as own admin

### DIFF
--- a/solidity/contracts/SwapperRegistry.sol
+++ b/solidity/contracts/SwapperRegistry.sol
@@ -23,8 +23,10 @@ contract SwapperRegistry is AccessControl, ISwapperRegistry {
     address[] memory _initialAdmins
   ) {
     if (_superAdmin == address(0)) revert ZeroAddress();
-    _setupRole(SUPER_ADMIN_ROLE, _superAdmin);
+    // We are setting the super admin role as its own admin so we can transfer it
+    _setRoleAdmin(SUPER_ADMIN_ROLE, SUPER_ADMIN_ROLE);
     _setRoleAdmin(ADMIN_ROLE, SUPER_ADMIN_ROLE);
+    _setupRole(SUPER_ADMIN_ROLE, _superAdmin);
     for (uint256 i; i < _initialAdmins.length; i++) {
       _setupRole(ADMIN_ROLE, _initialAdmins[i]);
     }

--- a/test/unit/swapper-registry.spec.ts
+++ b/test/unit/swapper-registry.spec.ts
@@ -54,6 +54,10 @@ describe('SwapperRegistry', () => {
         const hasRole = await swapperRegistry.hasRole(adminRole, admin.address);
         expect(hasRole).to.be.true;
       });
+      then('super admin role is set as super admin role', async () => {
+        const admin = await swapperRegistry.getRoleAdmin(superAdminRole);
+        expect(admin).to.equal(superAdminRole);
+      });
       then('super admin role is set as admin role', async () => {
         const admin = await swapperRegistry.getRoleAdmin(adminRole);
         expect(admin).to.equal(superAdminRole);


### PR DESCRIPTION
We are now setting the super admin role as its own admin, so we can transfer it in the future