### PR TITLE
refactor: set zero address as recipient

### DIFF
--- a/solidity/contracts/SwapAdapter.sol
+++ b/solidity/contracts/SwapAdapter.sol
@@ -78,7 +78,7 @@ abstract contract SwapAdapter is ISwapAdapter {
    * @param _recipient The recipient of the token balance
    */
   function _sendBalanceOnContractToRecipient(address _token, address _recipient) internal virtual {
-    if (_recipient == address(0)) revert ZeroAddress();
+    if (_recipient == address(0)) _recipient = msg.sender;
     if (_token == PROTOCOL_TOKEN) {
       uint256 _balance = address(this).balance;
       if (_balance > 0) {
@@ -103,7 +103,7 @@ abstract contract SwapAdapter is ISwapAdapter {
     uint256 _amount,
     address _recipient
   ) internal virtual {
-    if (_recipient == address(0)) revert ZeroAddress();
+    if (_recipient == address(0)) _recipient = msg.sender;
     if (_token == PROTOCOL_TOKEN) {
       payable(_recipient).sendValue(_amount);
     } else {


### PR DESCRIPTION
When preparing swaps, we realized that we sometimes needed the ability to send funds back to the `msg.sender`. Specially in the case of "buy orders", when we might need to send back some unspent tokens. We could do this by knowing the msg.sender beforehand, but prefer to go with the applied change.

So the idea is that if the zero address is set as recipient, we will send funds to the `msg.sender`. That way, our swap builder doesn't need to know the caller beforehand