### PR TITLE
feat: add token permit extension

### DIFF
--- a/solidity/contracts/extensions/TokenPermit.sol
+++ b/solidity/contracts/extensions/TokenPermit.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.8.7 <0.9.0;
+
+import '@openzeppelin/contracts/token/ERC20/extensions/draft-IERC20Permit.sol';
+
+abstract contract TokenPermit {
+  /**
+   * @notice Executes a permit on a ERC20 token that supports it
+   * @param _token The token that will execute the permit
+   * @param _owner The account that signed the permite
+   * @param _spender The account that is being approved
+   * @param _value The amount that is being approved
+   * @param _v Must produce valid secp256k1 signature from the holder along with `r` and `s`
+   * @param _r Must produce valid secp256k1 signature from the holder along with `v` and `s`
+   * @param _s Must produce valid secp256k1 signature from the holder along with `r` and `v`
+   */
+  function permit(
+    IERC20Permit _token,
+    address _owner,
+    address _spender,
+    uint256 _value,
+    uint256 _deadline,
+    uint8 _v,
+    bytes32 _r,
+    bytes32 _s
+  ) external payable {
+    _token.permit(_owner, _spender, _value, _deadline, _v, _r, _s);
+  }
+}

--- a/solidity/contracts/test/Extensions.sol
+++ b/solidity/contracts/test/Extensions.sol
@@ -10,6 +10,7 @@ import '../extensions/TakeManyRunSwapsAndTransferMany.sol';
 import '../extensions/GetBalances.sol';
 import '../extensions/RevokableWithGovernor.sol';
 import '../extensions/CollectableWithGovernor.sol';
+import '../extensions/TokenPermit.sol';
 
 contract Extensions is
   RunSwap,
@@ -20,7 +21,8 @@ contract Extensions is
   TakeManyRunSwapsAndTransferMany,
   GetBalances,
   RevokableWithGovernor,
-  CollectableWithGovernor
+  CollectableWithGovernor,
+  TokenPermit
 {
   struct TakeFromMsgSenderCall {
     IERC20 token;

--- a/test/unit/extensions/token-permit.spec.ts
+++ b/test/unit/extensions/token-permit.spec.ts
@@ -1,0 +1,49 @@
+import chai, { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { contract, given, then, when } from '@utils/bdd';
+import { Extensions, Extensions__factory, IERC20Permit } from '@typechained';
+import { snapshot } from '@utils/evm';
+import { FakeContract, smock } from '@defi-wonderland/smock';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { utils } from 'ethers';
+
+chai.use(smock.matchers);
+
+contract('TokenPermit', () => {
+  const ACCOUNT = '0x0000000000000000000000000000000000000001';
+
+  let caller: SignerWithAddress;
+  let extensions: Extensions;
+  let token: FakeContract<IERC20Permit>;
+  let snapshotId: string;
+
+  before('Setup accounts and contracts', async () => {
+    [caller] = await ethers.getSigners();
+    token = await smock.fake('IERC20Permit');
+    const factory: Extensions__factory = await ethers.getContractFactory('solidity/contracts/test/Extensions.sol:Extensions');
+    extensions = await factory.deploy(ACCOUNT, ACCOUNT);
+    snapshotId = await snapshot.take();
+  });
+
+  beforeEach(async () => {
+    await snapshot.revert(snapshotId);
+  });
+
+  describe('permit', () => {
+    const OWNER = '0x0000000000000000000000000000000000000001';
+    const SPENDER = '0x0000000000000000000000000000000000000002';
+    const VALUE = 10000;
+    const DEADLINE = 1234566;
+    const V = 12;
+    const R = utils.formatBytes32String('r');
+    const S = utils.formatBytes32String('s');
+    when('executing permit', () => {
+      given(async () => {
+        await extensions.permit(token.address, OWNER, SPENDER, VALUE, DEADLINE, V, R, S);
+      });
+      then('token permit is called correctly', async () => {
+        expect(token.permit).to.have.been.calledOnceWith(OWNER, SPENDER, VALUE, DEADLINE, V, R, S);
+      });
+    });
+  });
+});


### PR DESCRIPTION
We are now adding a new extension that executes an ERC20 permit. This can be very useful for swappers, so they can improve the UX