### PR TITLE
refactor: add permit and multicall to swap proxy

### DIFF
--- a/solidity/contracts/SwapProxy.sol
+++ b/solidity/contracts/SwapProxy.sol
@@ -9,6 +9,8 @@ import './extensions/TakeManyRunSwapsAndTransferMany.sol';
 import './extensions/CollectableWithGovernor.sol';
 import './extensions/RevokableWithGovernor.sol';
 import './extensions/GetBalances.sol';
+import './extensions/TokenPermit.sol';
+import './extensions/PayableMulticall.sol';
 
 /**
  * @notice This contract implements all swap extensions, so it can be used by EOAs or other contracts that do not have the extensions
@@ -21,7 +23,9 @@ contract SwapProxy is
   TakeManyRunSwapsAndTransferMany,
   CollectableWithGovernor,
   RevokableWithGovernor,
-  GetBalances
+  GetBalances,
+  TokenPermit,
+  PayableMulticall
 {
   constructor(address _swapperRegistry, address _governor) SwapAdapter(_swapperRegistry) Governable(_governor) {}
 }

--- a/solidity/contracts/extensions/PayableMulticall.sol
+++ b/solidity/contracts/extensions/PayableMulticall.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+
+pragma solidity >=0.8.7 <0.9.0;
+
+import '@openzeppelin/contracts/utils/Address.sol';
+
+/**
+ * @dev Adding this contract will enable batching calls. This is basically the same as Open Zeppelin's
+ *      Multicall contract, but we have made it payable. It supports both payable and non payable
+ *      functions. However, if `msg.value` is not zero, then non payable functions cannot be called.
+ *      Any contract that uses this Multicall version should be very careful when using msg.value.
+ *      For more context, read: https://github.com/Uniswap/v3-periphery/issues/52
+ */
+abstract contract PayableMulticall {
+  /**
+   * @notice Receives and executes a batch of function calls on this contract.
+   * @param _data A list of different function calls to execute
+   * @return _results The result of executing each of those calls
+   */
+  function multicall(bytes[] calldata _data) external payable returns (bytes[] memory _results) {
+    _results = new bytes[](_data.length);
+    for (uint256 i; i < _data.length; i++) {
+      _results[i] = Address.functionDelegateCall(address(this), _data[i]);
+    }
+    return _results;
+  }
+}

--- a/solidity/contracts/extensions/TokenPermit.sol
+++ b/solidity/contracts/extensions/TokenPermit.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.8.7 <0.9.0;
+
+import '@openzeppelin/contracts/token/ERC20/extensions/draft-IERC20Permit.sol';
+
+abstract contract TokenPermit {
+  /**
+   * @notice Executes a permit on a ERC20 token that supports it
+   * @param _token The token that will execute the permit
+   * @param _owner The account that signed the permite
+   * @param _spender The account that is being approved
+   * @param _value The amount that is being approved
+   * @param _v Must produce valid secp256k1 signature from the holder along with `r` and `s`
+   * @param _r Must produce valid secp256k1 signature from the holder along with `v` and `s`
+   * @param _s Must produce valid secp256k1 signature from the holder along with `r` and `v`
+   */
+  function permit(
+    IERC20Permit _token,
+    address _owner,
+    address _spender,
+    uint256 _value,
+    uint256 _deadline,
+    uint8 _v,
+    bytes32 _r,
+    bytes32 _s
+  ) external payable {
+    _token.permit(_owner, _spender, _value, _deadline, _v, _r, _s);
+  }
+}

--- a/solidity/contracts/test/Extensions.sol
+++ b/solidity/contracts/test/Extensions.sol
@@ -10,6 +10,7 @@ import '../extensions/TakeManyRunSwapsAndTransferMany.sol';
 import '../extensions/GetBalances.sol';
 import '../extensions/RevokableWithGovernor.sol';
 import '../extensions/CollectableWithGovernor.sol';
+import '../extensions/TokenPermit.sol';
 
 contract Extensions is
   RunSwap,
@@ -20,7 +21,8 @@ contract Extensions is
   TakeManyRunSwapsAndTransferMany,
   GetBalances,
   RevokableWithGovernor,
-  CollectableWithGovernor
+  CollectableWithGovernor,
+  TokenPermit
 {
   struct TakeFromMsgSenderCall {
     IERC20 token;

--- a/solidity/contracts/test/PayableMulticall.sol
+++ b/solidity/contracts/test/PayableMulticall.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: UNLICENSED
+
+pragma solidity >=0.8.7 <0.9.0;
+
+import '../extensions/PayableMulticall.sol';
+
+contract PayableMulticallMock is PayableMulticall {
+  // slither-disable-next-line arbitrary-send
+  function sendEthToAddress(address payable _recipient, uint256 _amount) external payable {
+    _recipient.transfer(_amount);
+  }
+}

--- a/test/integration/assertions.ts
+++ b/test/integration/assertions.ts
@@ -1,4 +1,4 @@
-import { IERC20 } from '@mean-finance/deterministic-factory';
+import { IERC20 } from 'typechained';
 import { expect } from 'chai';
 import { BigNumber } from 'ethers';
 import { ethers } from 'hardhat';

--- a/test/integration/dex-aggregators-integration.spec.ts
+++ b/test/integration/dex-aggregators-integration.spec.ts
@@ -2,27 +2,28 @@ import { ethers } from 'hardhat';
 import { given, then, when } from '@utils/bdd';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { JsonRpcSigner } from '@ethersproject/providers';
-import { IERC20, SwapperRegistry, SwapProxy } from '@typechained';
-import { BigNumber, utils } from 'ethers';
+import { IERC20, IERC20Permit, SwapperRegistry, SwapProxy } from '@typechained';
+import { BigNumber, constants, utils } from 'ethers';
 import { snapshot } from '@utils/evm';
+import { fromRpcSig } from 'ethereumjs-util';
 import { expectBalanceToBeEmpty, expectBalanceToBeGreatherThan } from './assertions';
 import { deployContractsAndReturnSigners, getQuoteAndAllowlistSwapper } from './utils';
 import { oneInchAdapter, paraswapAdapter, Quote, QuoteInput, zrxAdapter } from './dex-adapters';
 
-const AMOUNT_EXACT_IN = utils.parseEther('1');
-const AMOUNT_EXACT_OUT = utils.parseUnits('1000', 6);
+const AMOUNT_EXACT_OUT = utils.parseEther('1');
+const AMOUNT_EXACT_IN = utils.parseUnits('1000', 6);
 
-describe('DEX Aggregators - Integration', () => {
+describe.only('DEX Aggregators - Integration', () => {
   let registry: SwapperRegistry;
   let swapProxy: SwapProxy;
   let WETH: IERC20, USDC: IERC20;
-  let wethWhale: JsonRpcSigner;
+  let usdcWhale: JsonRpcSigner;
   let caller: SignerWithAddress, recipient: SignerWithAddress;
   let snapshotId: string;
 
   before(async () => {
-    ({ registry, swapProxy, WETH, USDC, wethWhale } = await deployContractsAndReturnSigners());
-    [caller, recipient] = await ethers.getSigners();
+    ({ registry, swapProxy, WETH, USDC, usdcWhale } = await deployContractsAndReturnSigners());
+    [caller, , recipient] = await ethers.getSigners();
     snapshotId = await snapshot.take();
   });
 
@@ -78,38 +79,75 @@ describe('DEX Aggregators - Integration', () => {
         const quote = await getQuoteAndAllowlistSwapper({
           swapProxy,
           registry,
-          tokenIn: WETH,
-          tokenOut: USDC,
+          tokenIn: USDC,
+          tokenOut: WETH,
           trade: type === 'Exact In' ? 'sell' : 'buy',
           amount: type === 'Exact In' ? AMOUNT_EXACT_IN : AMOUNT_EXACT_OUT,
           recipient: recipient,
           quoter,
         });
         minAmountOut = quote.minAmountOut;
-        await WETH.connect(wethWhale).transfer(caller.address, quote.maxAmountIn);
-        await WETH.connect(caller).approve(swapProxy.address, quote.maxAmountIn);
-        await swapProxy.connect(caller).takeRunSwapAndTransfer({
+        await USDC.connect(usdcWhale).transfer(caller.address, quote.maxAmountIn);
+
+        const { v, r, s } = await getSignature(caller, swapProxy.address, quote.maxAmountIn);
+        const { data: permitData } = await swapProxy.populateTransaction.permit(
+          USDC.address,
+          caller.address,
+          swapProxy.address,
+          quote.maxAmountIn,
+          constants.MaxUint256,
+          v,
+          r,
+          s
+        );
+
+        const { data: swapData } = await swapProxy.populateTransaction.takeRunSwapAndTransfer({
           swapper: quote.swapperAddress,
           allowanceTarget: quote.allowanceTarget,
           swapData: quote.data,
-          tokenIn: WETH.address,
+          tokenIn: USDC.address,
           maxAmountIn: quote.maxAmountIn,
-          tokenOut: USDC.address,
+          tokenOut: WETH.address,
           recipient: recipient.address,
           checkUnspentTokensIn: !!checkUnspentTokensIn,
         });
+
+        await swapProxy.connect(caller).multicall([permitData!, swapData!]);
       });
 
       when('swap & transfer is executed through the swap proxy', () => {
         if (!checkUnspentTokensIn) {
-          then(`caller has no 'from' token left`, () => expectBalanceToBeEmpty(WETH, caller));
+          then(`caller has no 'from' token left`, () => expectBalanceToBeEmpty(USDC, caller));
         }
-        then(`caller has no 'to' token`, () => expectBalanceToBeEmpty(USDC, caller));
-        then(`proxy has no 'from' token left`, () => expectBalanceToBeEmpty(WETH, swapProxy));
-        then(`proxy has no 'to' token left`, () => expectBalanceToBeEmpty(USDC, swapProxy));
-        then(`recipient has no 'from' token`, () => expectBalanceToBeEmpty(WETH, recipient));
-        then(`recipient has the expected amount of 'to' token`, () => expectBalanceToBeGreatherThan(USDC, minAmountOut, recipient));
+        then(`caller has no 'to' token`, () => expectBalanceToBeEmpty(WETH, caller));
+        then(`proxy has no 'from' token left`, () => expectBalanceToBeEmpty(USDC, swapProxy));
+        then(`proxy has no 'to' token left`, () => expectBalanceToBeEmpty(WETH, swapProxy));
+        then(`recipient has no 'from' token`, () => expectBalanceToBeEmpty(USDC, recipient));
+        then(`recipient has the expected amount of 'to' token`, () => expectBalanceToBeGreatherThan(WETH, minAmountOut, recipient));
       });
     });
+  }
+
+  const Permit = [
+    { name: 'owner', type: 'address' },
+    { name: 'spender', type: 'address' },
+    { name: 'value', type: 'uint256' },
+    { name: 'nonce', type: 'uint256' },
+    { name: 'deadline', type: 'uint256' },
+  ];
+
+  async function getSignature(owner: SignerWithAddress, spender: string, amount: BigNumber) {
+    const nonce = await (USDC as any as IERC20Permit).nonces(owner.address);
+    const { domain, types, value } = buildPermitData(owner, spender, amount, nonce);
+    const signature = await owner._signTypedData(domain, types, value);
+    return fromRpcSig(signature);
+  }
+
+  function buildPermitData(owner: SignerWithAddress, spender: string, amount: BigNumber, nonce: BigNumber) {
+    return {
+      types: { Permit },
+      domain: { name: 'USD Coin', version: '2', chainId: 1, verifyingContract: USDC.address },
+      value: { owner: owner.address, spender, value: amount, nonce, deadline: constants.MaxUint256 },
+    };
   }
 });

--- a/test/integration/dex-aggregators-integration.spec.ts
+++ b/test/integration/dex-aggregators-integration.spec.ts
@@ -13,7 +13,7 @@ import { oneInchAdapter, paraswapAdapter, Quote, QuoteInput, zrxAdapter } from '
 const AMOUNT_EXACT_OUT = utils.parseEther('1');
 const AMOUNT_EXACT_IN = utils.parseUnits('1000', 6);
 
-describe.only('DEX Aggregators - Integration', () => {
+describe('DEX Aggregators - Integration', () => {
   let registry: SwapperRegistry;
   let swapProxy: SwapProxy;
   let WETH: IERC20, USDC: IERC20;

--- a/test/integration/utils.ts
+++ b/test/integration/utils.ts
@@ -6,6 +6,7 @@ import { deployments, ethers, getNamedAccounts } from 'hardhat';
 import { DeterministicFactory, DeterministicFactory__factory } from '@mean-finance/deterministic-factory';
 import { QuoteInput, Quote } from './dex-adapters';
 import { abi as IERC20_ABI } from '@openzeppelin/contracts/build/contracts/IERC20.json';
+import { abi as IERC20_PERMIT_ABI } from '@openzeppelin/contracts/build/contracts/IERC20Permit.json';
 
 export const ETH_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
 const WETH_ADDRESS = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
@@ -73,7 +74,7 @@ export async function deployContractsAndReturnSigners() {
   const registry = await ethers.getContract<SwapperRegistry>('SwapperRegistry');
   const swapProxy = await ethers.getContract<SwapProxy>('SwapProxy');
   const WETH = await ethers.getContractAt<IERC20>(IERC20_ABI, WETH_ADDRESS);
-  const USDC = await ethers.getContractAt<IERC20>(IERC20_ABI, USDC_ADDRESS);
+  const USDC = await ethers.getContractAt<IERC20>([...IERC20_ABI, ...IERC20_PERMIT_ABI], USDC_ADDRESS);
   const MANA = await ethers.getContractAt<IERC20>(IERC20_ABI, MANA_ADDRESS);
 
   const wethWhale = await wallet.impersonate(WETH_WHALE_ADDRESS);

--- a/test/integration/utils.ts
+++ b/test/integration/utils.ts
@@ -6,7 +6,6 @@ import { deployments, ethers, getNamedAccounts } from 'hardhat';
 import { DeterministicFactory, DeterministicFactory__factory } from '@mean-finance/deterministic-factory';
 import { QuoteInput, Quote } from './dex-adapters';
 import { abi as IERC20_ABI } from '@openzeppelin/contracts/build/contracts/IERC20.json';
-import { abi as IERC20_PERMIT_ABI } from '@openzeppelin/contracts/build/contracts/IERC20Permit.json';
 
 export const ETH_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
 const WETH_ADDRESS = '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2';
@@ -74,7 +73,7 @@ export async function deployContractsAndReturnSigners() {
   const registry = await ethers.getContract<SwapperRegistry>('SwapperRegistry');
   const swapProxy = await ethers.getContract<SwapProxy>('SwapProxy');
   const WETH = await ethers.getContractAt<IERC20>(IERC20_ABI, WETH_ADDRESS);
-  const USDC = await ethers.getContractAt<IERC20>([...IERC20_ABI, ...IERC20_PERMIT_ABI], USDC_ADDRESS);
+  const USDC = await ethers.getContractAt<IERC20>(IERC20_ABI, USDC_ADDRESS);
   const MANA = await ethers.getContractAt<IERC20>(IERC20_ABI, MANA_ADDRESS);
 
   const wethWhale = await wallet.impersonate(WETH_WHALE_ADDRESS);

--- a/test/unit/extensions/payable-multicall.spec.ts
+++ b/test/unit/extensions/payable-multicall.spec.ts
@@ -7,7 +7,7 @@ import { snapshot } from '@utils/evm';
 import { PayableMulticallMock, PayableMulticallMock__factory } from '@typechained';
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 
-describe.only('Multicall', function () {
+describe('Multicall', function () {
   let signer: SignerWithAddress;
   let recipient1: SignerWithAddress, recipient2: SignerWithAddress, recipient3: SignerWithAddress;
   let multicall: PayableMulticallMock;

--- a/test/unit/extensions/payable-multicall.spec.ts
+++ b/test/unit/extensions/payable-multicall.spec.ts
@@ -1,0 +1,74 @@
+import { BigNumber, BytesLike, constants, utils } from 'ethers';
+import { ethers } from 'hardhat';
+import { TransactionResponse } from '@ethersproject/abstract-provider';
+import { given, then, when } from '../../utils/bdd';
+import { expect } from 'chai';
+import { snapshot } from '@utils/evm';
+import { PayableMulticallMock, PayableMulticallMock__factory } from '@typechained';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+
+describe.only('Multicall', function () {
+  let signer: SignerWithAddress;
+  let recipient1: SignerWithAddress, recipient2: SignerWithAddress, recipient3: SignerWithAddress;
+  let multicall: PayableMulticallMock;
+  let snapshotId: string;
+
+  before('Setup accounts and contracts', async () => {
+    [signer, recipient1, recipient2, recipient3] = await ethers.getSigners();
+    const factory: PayableMulticallMock__factory = await ethers.getContractFactory('PayableMulticallMock');
+    multicall = await factory.deploy();
+    snapshotId = await snapshot.take();
+  });
+
+  beforeEach(async () => {
+    await snapshot.revert(snapshotId);
+  });
+
+  /*
+  We've built our own multicall so that we can make it payable. The idea is that we can send a lot of ether
+  to the multicall and use different portions in different subcalls. So we will now be testing that we can
+  actually distribute it.  
+  */
+  describe('multicall', () => {
+    when('using multicall for distribute ether', () => {
+      let recipients: { address: string; toTransfer: BigNumber }[];
+      let initialBalances: Map<string, BigNumber> = new Map();
+      given(async () => {
+        recipients = [
+          { address: recipient1.address, toTransfer: utils.parseEther('0.1') },
+          { address: recipient2.address, toTransfer: utils.parseEther('0.2') },
+          { address: recipient3.address, toTransfer: utils.parseEther('0.3') },
+        ];
+
+        let total = constants.Zero;
+        let calls: BytesLike[] = [];
+        for (const { address, toTransfer } of recipients) {
+          total = total.add(toTransfer);
+          initialBalances.set(address, await ethers.provider.getBalance(address));
+          const { data } = await multicall.populateTransaction.sendEthToAddress(address, toTransfer);
+          calls.push(data!);
+        }
+        await multicall.multicall(calls, { value: total });
+      });
+      then('ether is transferred correctly', async () => {
+        for (const { address, toTransfer } of recipients) {
+          expect(await ethers.provider.getBalance(address)).to.equal(initialBalances.get(address)!.add(toTransfer));
+        }
+      });
+      then('multicall contract has no balance left', async () => {
+        expect(await ethers.provider.getBalance(multicall.address)).to.equal(0);
+      });
+    });
+  });
+  when('using multicall to move more ether than sent to multicall', () => {
+    let tx: Promise<TransactionResponse>;
+    given(async () => {
+      const toTransfer = utils.parseEther('0.1');
+      const { data } = await multicall.populateTransaction.sendEthToAddress(recipient1.address, toTransfer);
+      tx = multicall.multicall([data!], { value: toTransfer.sub(1) });
+    });
+    then('tx reverts', async () => {
+      await expect(tx).to.have.reverted;
+    });
+  });
+});

--- a/test/unit/extensions/token-permit.spec.ts
+++ b/test/unit/extensions/token-permit.spec.ts
@@ -1,0 +1,49 @@
+import chai, { expect } from 'chai';
+import { ethers } from 'hardhat';
+import { contract, given, then, when } from '@utils/bdd';
+import { Extensions, Extensions__factory, IERC20Permit } from '@typechained';
+import { snapshot } from '@utils/evm';
+import { FakeContract, smock } from '@defi-wonderland/smock';
+import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
+import { utils } from 'ethers';
+
+chai.use(smock.matchers);
+
+contract('TokenPermit', () => {
+  const ACCOUNT = '0x0000000000000000000000000000000000000001';
+
+  let caller: SignerWithAddress;
+  let extensions: Extensions;
+  let token: FakeContract<IERC20Permit>;
+  let snapshotId: string;
+
+  before('Setup accounts and contracts', async () => {
+    [caller] = await ethers.getSigners();
+    token = await smock.fake('IERC20Permit');
+    const factory: Extensions__factory = await ethers.getContractFactory('solidity/contracts/test/Extensions.sol:Extensions');
+    extensions = await factory.deploy(ACCOUNT, ACCOUNT);
+    snapshotId = await snapshot.take();
+  });
+
+  beforeEach(async () => {
+    await snapshot.revert(snapshotId);
+  });
+
+  describe('permit', () => {
+    const OWNER = '0x0000000000000000000000000000000000000001';
+    const SPENDER = '0x0000000000000000000000000000000000000002';
+    const VALUE = 10000;
+    const DEADLINE = 1234566;
+    const V = 12;
+    const R = utils.formatBytes32String('r');
+    const S = utils.formatBytes32String('s');
+    when('executing permit', () => {
+      given(async () => {
+        await extensions.permit(token.address, OWNER, SPENDER, VALUE, DEADLINE, V, R, S);
+      });
+      then('token permit is called correctly', async () => {
+        expect(token.permit).to.have.been.calledOnceWith(OWNER, SPENDER, VALUE, DEADLINE, V, R, S);
+      });
+    });
+  });
+});


### PR DESCRIPTION
We are now adding the `TokenPermit` and `PayableMulticall` extensions to the Swap Proxy. Now we can add permit + execute swaps in one tx!