### PR TITLE
refactor: use send to recipient from other send

### DIFF
--- a/solidity/contracts/SwapAdapter.sol
+++ b/solidity/contracts/SwapAdapter.sol
@@ -78,17 +78,9 @@ abstract contract SwapAdapter is ISwapAdapter {
    * @param _recipient The recipient of the token balance
    */
   function _sendBalanceOnContractToRecipient(address _token, address _recipient) internal virtual {
-    if (_recipient == address(0)) _recipient = msg.sender;
-    if (_token == PROTOCOL_TOKEN) {
-      uint256 _balance = address(this).balance;
-      if (_balance > 0) {
-        payable(_recipient).sendValue(_balance);
-      }
-    } else {
-      uint256 _balance = IERC20(_token).balanceOf(address(this));
-      if (_balance > 0) {
-        IERC20(_token).safeTransfer(_recipient, _balance);
-      }
+    uint256 _balance = _token == PROTOCOL_TOKEN ? address(this).balance : IERC20(_token).balanceOf(address(this));
+    if (_balance > 0) {
+      _sendToRecipient(_token, _balance, _recipient);
     }
   }
 

--- a/solidity/contracts/SwapAdapter.sol
+++ b/solidity/contracts/SwapAdapter.sol
@@ -125,10 +125,16 @@ abstract contract SwapAdapter is ISwapAdapter {
    * @param _revokeActions The spenders and tokens to revoke
    */
   function _revokeAllowances(RevokeAction[] calldata _revokeActions) internal virtual {
-    for (uint256 i; i < _revokeActions.length; i++) {
+    for (uint256 i = 0; i < _revokeActions.length; ) {
       RevokeAction memory _action = _revokeActions[i];
-      for (uint256 j; j < _action.tokens.length; j++) {
+      for (uint256 j = 0; j < _action.tokens.length; ) {
         _action.tokens[j].approve(_action.spender, 0);
+        unchecked {
+          j++;
+        }
+      }
+      unchecked {
+        i++;
       }
     }
   }

--- a/solidity/contracts/SwapperRegistry.sol
+++ b/solidity/contracts/SwapperRegistry.sol
@@ -27,20 +27,29 @@ contract SwapperRegistry is AccessControl, ISwapperRegistry {
     _setRoleAdmin(SUPER_ADMIN_ROLE, SUPER_ADMIN_ROLE);
     _setRoleAdmin(ADMIN_ROLE, SUPER_ADMIN_ROLE);
     _setupRole(SUPER_ADMIN_ROLE, _superAdmin);
-    for (uint256 i; i < _initialAdmins.length; i++) {
+    for (uint256 i = 0; i < _initialAdmins.length; ) {
       _setupRole(ADMIN_ROLE, _initialAdmins[i]);
+      unchecked {
+        i++;
+      }
     }
 
     if (_initialSupplementaryAllowanceTargets.length > 0) {
-      for (uint256 i; i < _initialSupplementaryAllowanceTargets.length; i++) {
+      for (uint256 i = 0; i < _initialSupplementaryAllowanceTargets.length; ) {
         _accountRole[_initialSupplementaryAllowanceTargets[i]] = Role.SUPPLEMENTARY_ALLOWANCE_TARGET;
+        unchecked {
+          i++;
+        }
       }
       emit AllowedSupplementaryAllowanceTargets(_initialSupplementaryAllowanceTargets);
     }
 
     if (_initialSwappersAllowlisted.length > 0) {
-      for (uint256 i; i < _initialSwappersAllowlisted.length; i++) {
+      for (uint256 i = 0; i < _initialSwappersAllowlisted.length; ) {
         _accountRole[_initialSwappersAllowlisted[i]] = Role.SWAPPER;
+        unchecked {
+          i++;
+        }
       }
       emit AllowedSwappers(_initialSwappersAllowlisted);
     }
@@ -58,32 +67,44 @@ contract SwapperRegistry is AccessControl, ISwapperRegistry {
 
   /// @inheritdoc ISwapperRegistry
   function allowSwappers(address[] calldata _swappers) external onlyRole(ADMIN_ROLE) {
-    for (uint256 i; i < _swappers.length; i++) {
+    for (uint256 i = 0; i < _swappers.length; ) {
       _accountRole[_swappers[i]] = Role.SWAPPER;
+      unchecked {
+        i++;
+      }
     }
     emit AllowedSwappers(_swappers);
   }
 
   /// @inheritdoc ISwapperRegistry
   function removeSwappersFromAllowlist(address[] calldata _swappers) external onlyRole(ADMIN_ROLE) {
-    for (uint256 i; i < _swappers.length; i++) {
+    for (uint256 i = 0; i < _swappers.length; ) {
       _accountRole[_swappers[i]] = Role.NONE;
+      unchecked {
+        i++;
+      }
     }
     emit RemoveSwappersFromAllowlist(_swappers);
   }
 
   /// @inheritdoc ISwapperRegistry
   function allowSupplementaryAllowanceTargets(address[] calldata _allowanceTargets) external onlyRole(ADMIN_ROLE) {
-    for (uint256 i; i < _allowanceTargets.length; i++) {
+    for (uint256 i = 0; i < _allowanceTargets.length; ) {
       _accountRole[_allowanceTargets[i]] = Role.SUPPLEMENTARY_ALLOWANCE_TARGET;
+      unchecked {
+        i++;
+      }
     }
     emit AllowedSupplementaryAllowanceTargets(_allowanceTargets);
   }
 
   /// @inheritdoc ISwapperRegistry
   function removeSupplementaryAllowanceTargetsFromAllowlist(address[] calldata _allowanceTargets) external onlyRole(ADMIN_ROLE) {
-    for (uint256 i; i < _allowanceTargets.length; i++) {
+    for (uint256 i = 0; i < _allowanceTargets.length; ) {
       _accountRole[_allowanceTargets[i]] = Role.NONE;
+      unchecked {
+        i++;
+      }
     }
     emit RemovedAllowanceTargetsFromAllowlist(_allowanceTargets);
   }

--- a/solidity/contracts/extensions/GetBalances.sol
+++ b/solidity/contracts/extensions/GetBalances.sol
@@ -19,9 +19,12 @@ abstract contract GetBalances is SwapAdapter {
    */
   function getBalances(address[] calldata _tokens) external view returns (TokenBalance[] memory _balances) {
     _balances = new TokenBalance[](_tokens.length);
-    for (uint256 i; i < _tokens.length; i++) {
+    for (uint256 i = 0; i < _tokens.length; ) {
       uint256 _balance = _tokens[i] == PROTOCOL_TOKEN ? address(this).balance : IERC20(_tokens[i]).balanceOf(address(this));
       _balances[i] = TokenBalance({token: _tokens[i], balance: _balance});
+      unchecked {
+        i++;
+      }
     }
   }
 }

--- a/solidity/contracts/extensions/PayableMulticall.sol
+++ b/solidity/contracts/extensions/PayableMulticall.sol
@@ -19,8 +19,11 @@ abstract contract PayableMulticall {
    */
   function multicall(bytes[] calldata _data) external payable returns (bytes[] memory _results) {
     _results = new bytes[](_data.length);
-    for (uint256 i; i < _data.length; i++) {
+    for (uint256 i = 0; i < _data.length; ) {
       _results[i] = Address.functionDelegateCall(address(this), _data[i]);
+      unchecked {
+        i++;
+      }
     }
     return _results;
   }

--- a/solidity/contracts/extensions/TakeManyRunSwapAndTransferMany.sol
+++ b/solidity/contracts/extensions/TakeManyRunSwapAndTransferMany.sol
@@ -29,7 +29,7 @@ abstract contract TakeManyRunSwapAndTransferMany is SwapAdapter {
    * @param _parameters The parameters for the swap
    */
   function takeManyRunSwapAndTransferMany(TakeManyRunSwapAndTransferManyParams calldata _parameters) public payable virtual {
-    for (uint256 i; i < _parameters.takeFromCaller.length; i++) {
+    for (uint256 i = 0; i < _parameters.takeFromCaller.length; ) {
       // Take from caller
       TakeFromCaller memory _takeFromCaller = _parameters.takeFromCaller[i];
       _takeFromMsgSender(_takeFromCaller.token, _takeFromCaller.amount);
@@ -41,6 +41,9 @@ abstract contract TakeManyRunSwapAndTransferMany is SwapAdapter {
         _parameters.allowanceTarget == _parameters.swapper,
         _takeFromCaller.amount
       );
+      unchecked {
+        i++;
+      }
     }
 
     // Validate that the swapper is allowlisted
@@ -50,9 +53,12 @@ abstract contract TakeManyRunSwapAndTransferMany is SwapAdapter {
     _executeSwap(_parameters.swapper, _parameters.swapData, _parameters.valueInSwap);
 
     // Transfer out whatever was left in the contract
-    for (uint256 i; i < _parameters.transferOutBalance.length; i++) {
+    for (uint256 i = 0; i < _parameters.transferOutBalance.length; ) {
       TransferOutBalance memory _transferOutBalance = _parameters.transferOutBalance[i];
       _sendBalanceOnContractToRecipient(_transferOutBalance.token, _transferOutBalance.recipient);
+      unchecked {
+        i++;
+      }
     }
   }
 }

--- a/solidity/contracts/extensions/TakeManyRunSwapsAndTransferMany.sol
+++ b/solidity/contracts/extensions/TakeManyRunSwapsAndTransferMany.sol
@@ -31,32 +31,47 @@ abstract contract TakeManyRunSwapsAndTransferMany is SwapAdapter {
    */
   function takeManyRunSwapsAndTransferMany(TakeManyRunSwapsAndTransferManyParams calldata _parameters) public payable virtual {
     // Take from caller
-    for (uint256 i; i < _parameters.takeFromCaller.length; i++) {
+    for (uint256 i = 0; i < _parameters.takeFromCaller.length; ) {
       TakeFromCaller memory _takeFromCaller = _parameters.takeFromCaller[i];
       _takeFromMsgSender(_takeFromCaller.token, _takeFromCaller.amount);
+      unchecked {
+        i++;
+      }
     }
 
     // Validate that all swappers are allowlisted
-    for (uint256 i; i < _parameters.swappers.length; i++) {
+    for (uint256 i = 0; i < _parameters.swappers.length; ) {
       _assertSwapperIsAllowlisted(_parameters.swappers[i]);
+      unchecked {
+        i++;
+      }
     }
 
     // Approve whatever is necessary
-    for (uint256 i; i < _parameters.allowanceTargets.length; i++) {
+    for (uint256 i = 0; i < _parameters.allowanceTargets.length; ) {
       Allowance memory _allowance = _parameters.allowanceTargets[i];
       _maxApproveSpenderIfNeeded(_allowance.token, _allowance.allowanceTarget, false, _allowance.minAllowance);
+      unchecked {
+        i++;
+      }
     }
 
     // Execute swaps
-    for (uint256 i; i < _parameters.swaps.length; i++) {
+    for (uint256 i = 0; i < _parameters.swaps.length; ) {
       SwapContext memory _context = _parameters.swapContext[i];
       _executeSwap(_parameters.swappers[_context.swapperIndex], _parameters.swaps[i], _context.value);
+      unchecked {
+        i++;
+      }
     }
 
     // Transfer out whatever was left in the contract
-    for (uint256 i; i < _parameters.transferOutBalance.length; i++) {
+    for (uint256 i = 0; i < _parameters.transferOutBalance.length; ) {
       TransferOutBalance memory _transferOutBalance = _parameters.transferOutBalance[i];
       _sendBalanceOnContractToRecipient(_transferOutBalance.token, _transferOutBalance.recipient);
+      unchecked {
+        i++;
+      }
     }
   }
 }

--- a/solidity/contracts/extensions/TakeRunSwapsAndTransferMany.sol
+++ b/solidity/contracts/extensions/TakeRunSwapsAndTransferMany.sol
@@ -38,26 +38,38 @@ abstract contract TakeRunSwapsAndTransferMany is SwapAdapter {
     }
 
     // Validate that all swappers are allowlisted
-    for (uint256 i; i < _parameters.swappers.length; i++) {
+    for (uint256 i = 0; i < _parameters.swappers.length; ) {
       _assertSwapperIsAllowlisted(_parameters.swappers[i]);
+      unchecked {
+        i++;
+      }
     }
 
     // Approve whatever is necessary
-    for (uint256 i; i < _parameters.allowanceTargets.length; i++) {
+    for (uint256 i = 0; i < _parameters.allowanceTargets.length; ) {
       Allowance memory _allowance = _parameters.allowanceTargets[i];
       _maxApproveSpenderIfNeeded(_allowance.token, _allowance.allowanceTarget, false, _allowance.minAllowance);
+      unchecked {
+        i++;
+      }
     }
 
     // Execute swaps
-    for (uint256 i; i < _parameters.swaps.length; i++) {
+    for (uint256 i = 0; i < _parameters.swaps.length; ) {
       SwapContext memory _context = _parameters.swapContext[i];
       _executeSwap(_parameters.swappers[_context.swapperIndex], _parameters.swaps[i], _context.value);
+      unchecked {
+        i++;
+      }
     }
 
     // Transfer out whatever was left in the contract
-    for (uint256 i; i < _parameters.transferOutBalance.length; i++) {
+    for (uint256 i = 0; i < _parameters.transferOutBalance.length; ) {
       TransferOutBalance memory _transferOutBalance = _parameters.transferOutBalance[i];
       _sendBalanceOnContractToRecipient(_transferOutBalance.token, _transferOutBalance.recipient);
+      unchecked {
+        i++;
+      }
     }
   }
 }

--- a/solidity/contracts/test/Extensions.sol
+++ b/solidity/contracts/test/Extensions.sol
@@ -118,8 +118,11 @@ contract Extensions is
   function _revokeAllowances(RevokeAction[] calldata _revokeActions) internal override {
     _revokeCalls.push();
     uint256 _currentCall = _revokeCalls.length - 1;
-    for (uint256 i; i < _revokeActions.length; i++) {
+    for (uint256 i = 0; i < _revokeActions.length; ) {
       _revokeCalls[_currentCall].push(_revokeActions[i]);
+      unchecked {
+        i++;
+      }
     }
     super._revokeAllowances(_revokeActions);
   }


### PR DESCRIPTION
We are now making code simpler by calling `_sendToRecipient` from `_sendBalanceOnContractToRecipient`, since a big part of the code was the same