### PR TITLE
feat: perform checks on role management

### DIFF
--- a/solidity/interfaces/ISwapperRegistry.sol
+++ b/solidity/interfaces/ISwapperRegistry.sol
@@ -11,6 +11,18 @@ interface ISwapperRegistry {
   /// @notice Thrown when one of the parameters is a zero address
   error ZeroAddress();
 
+  /// @notice Thrown when trying to remove an account from the swappers list, when it wasn't there before
+  error AccountIsNotSwapper(address account);
+
+  /**
+   * @notice Thrown when trying to remove an account from the supplementary allowance target list,
+   *         when it wasn't there before
+   */
+  error AccountIsNotSupplementaryAllowanceTarget(address account);
+
+  /// @notice Thrown when trying to mark an account as swapper or allowance target, but it already has a role assigned
+  error AccountAlreadyHasRole(address account);
+
   /**
    * @notice Emitted when swappers are removed from the allowlist
    * @param swappers The swappers that were removed

--- a/test/integration/utils.ts
+++ b/test/integration/utils.ts
@@ -61,7 +61,9 @@ export async function getQuoteAndAllowlistSwapper({
   const { msig: adminAddress } = await getNamedAccounts();
   const admin = await wallet.impersonate(adminAddress);
   await ethers.provider.send('hardhat_setBalance', [adminAddress, '0xffffffffffffffff']);
-  await registry.connect(admin).allowSwappers([quote.swapperAddress]);
+  if (!(await registry.isSwapperAllowlisted(quote.swapperAddress))) {
+    await registry.connect(admin).allowSwappers([quote.swapperAddress]);
+  }
   if (quote.allowanceTarget !== quote.swapperAddress) {
     await registry.connect(admin).allowSupplementaryAllowanceTargets([quote.allowanceTarget]);
   }

--- a/test/unit/swapper-registry.spec.ts
+++ b/test/unit/swapper-registry.spec.ts
@@ -90,6 +90,16 @@ describe('SwapperRegistry', () => {
         await expect(tx).to.emit(swapperRegistry, 'AllowedSwappers').withArgs([NOT_ALLOWED_SWAPPER]);
       });
     });
+    when('swapper was already allowed', () => {
+      then('reverts with message', async () => {
+        await behaviours.txShouldRevertWithMessage({
+          contract: swapperRegistry.connect(admin),
+          func: 'allowSwappers',
+          args: [[ALLOWED_SWAPPER]],
+          message: `AccountAlreadyHasRole("${ALLOWED_SWAPPER}")`,
+        });
+      });
+    });
     behaviours.shouldBeExecutableOnlyByRole({
       contract: () => swapperRegistry,
       funcAndSignature: 'allowSwappers',
@@ -115,6 +125,16 @@ describe('SwapperRegistry', () => {
         await expect(tx).to.emit(swapperRegistry, 'RemoveSwappersFromAllowlist').withArgs([ALLOWED_SWAPPER]);
       });
     });
+    when('trying to remove an account that was not a swapper', () => {
+      then('reverts with message', async () => {
+        await behaviours.txShouldRevertWithMessage({
+          contract: swapperRegistry.connect(admin),
+          func: 'removeSwappersFromAllowlist',
+          args: [[NOT_ALLOWED_SWAPPER]],
+          message: `AccountIsNotSwapper("${NOT_ALLOWED_SWAPPER}")`,
+        });
+      });
+    });
     behaviours.shouldBeExecutableOnlyByRole({
       contract: () => swapperRegistry,
       funcAndSignature: 'removeSwappersFromAllowlist',
@@ -137,6 +157,16 @@ describe('SwapperRegistry', () => {
         await expect(tx).to.emit(swapperRegistry, 'AllowedSupplementaryAllowanceTargets').withArgs([NOT_ALLOWED_SUPPLEMENTARY_ALLOWANCE_TARGET]);
       });
     });
+    when('allowance target was already allowed', () => {
+      then('reverts with message', async () => {
+        await behaviours.txShouldRevertWithMessage({
+          contract: swapperRegistry.connect(admin),
+          func: 'allowSupplementaryAllowanceTargets',
+          args: [[SUPPLEMENTARY_ALLOWANCE_TARGET]],
+          message: `AccountAlreadyHasRole("${SUPPLEMENTARY_ALLOWANCE_TARGET}")`,
+        });
+      });
+    });
     behaviours.shouldBeExecutableOnlyByRole({
       contract: () => swapperRegistry,
       funcAndSignature: 'allowSupplementaryAllowanceTargets',
@@ -157,6 +187,16 @@ describe('SwapperRegistry', () => {
       });
       then('event is emitted', async () => {
         await expect(tx).to.emit(swapperRegistry, 'RemovedAllowanceTargetsFromAllowlist').withArgs([SUPPLEMENTARY_ALLOWANCE_TARGET]);
+      });
+    });
+    when('trying to remove an account that was not an allowance target', () => {
+      then('reverts with message', async () => {
+        await behaviours.txShouldRevertWithMessage({
+          contract: swapperRegistry.connect(admin),
+          func: 'removeSupplementaryAllowanceTargetsFromAllowlist',
+          args: [[NOT_ALLOWED_SUPPLEMENTARY_ALLOWANCE_TARGET]],
+          message: `AccountIsNotSupplementaryAllowanceTarget("${NOT_ALLOWED_SUPPLEMENTARY_ALLOWANCE_TARGET}")`,
+        });
       });
     });
     behaviours.shouldBeExecutableOnlyByRole({


### PR DESCRIPTION
We are now performing checks before updating roles (swapper or allowance target), so that we fail if the operation does not make sense